### PR TITLE
feat: Enhance Excel export functionality and add template creation method

### DIFF
--- a/Futurist.Web/Controllers/BomStdController.cs
+++ b/Futurist.Web/Controllers/BomStdController.cs
@@ -43,12 +43,24 @@ public class BomStdController : Controller
         
         var stream = ExcelHelper.ExportExcel(response.Data, (row, dto) =>
         {
-            row.Cell(1).Value = dto.Room;
-            row.Cell(2).Value = dto.ProductId;
-            row.Cell(3).Value = dto.ProductName;
-            row.Cell(4).Value = dto.BomId;
-            row.Cell(5).Value = dto.ItemId;
-            row.Cell(6).Value = dto.ItemName;
+            if (row.RowNumber() == 1)
+            {
+                row.Cell(1).Value = "Room";
+                row.Cell(2).Value = "Product Id";
+                row.Cell(3).Value = "Product Name";
+                row.Cell(4).Value = "Bom Id";
+                row.Cell(5).Value = "Item Id";
+                row.Cell(6).Value = "Item Name";
+            }
+            else
+            {
+                row.Cell(1).Value = dto.Room;
+                row.Cell(2).Value = dto.ProductId;
+                row.Cell(3).Value = dto.ProductName;
+                row.Cell(4).Value = dto.BomId;
+                row.Cell(5).Value = dto.ItemId;
+                row.Cell(6).Value = dto.ItemName;
+            }
         });
         
         return File(stream, "text/csv", $"BomErrorCheck_{DateTime.Now:yyyyMMddHHmmss}.csv");

--- a/Futurist.Web/Controllers/FgCostController.cs
+++ b/Futurist.Web/Controllers/FgCostController.cs
@@ -1,4 +1,5 @@
-﻿using Futurist.Service.Dto;
+﻿using ClosedXML.Excel;
+using Futurist.Common.Helpers;
 using Futurist.Service.Dto.Common;
 using Futurist.Service.Interface;
 using Microsoft.AspNetCore.Authorization;
@@ -67,6 +68,193 @@ public class FgCostController : Controller
     {
         ViewBag.RofoId = id;
         return View();
+    }
+    
+    public async Task<IActionResult> DownloadSummaryFgCost([FromQuery] int room)
+    {
+        var response = await _fgCostService.GetSummaryFgCostAsync(room);
+
+        if (response is not { IsSuccess: true, Data: not null }) return BadRequest(response.Errors);
+        
+        var result = ExcelHelper.ExportExcel(response.Data, (row, dto) =>
+        {
+            if (row.RowNumber() == 1)
+            {
+                row.Cell(1).Value = "Room";
+                row.Cell(2).Value = "Rofo ID";
+                row.Cell(3).Value = "Product ID";
+                row.Cell(4).Value = "Product Name";
+                row.Cell(5).Value = "Unit";
+                row.Cell(6).Value = "Unit in Kg";
+                row.Cell(7).Value = "Rofo Date";
+                row.Cell(8).Value = "Qty Rofo";
+                row.Cell(9).Value = "Yield";
+                row.Cell(10).Value = "RM Price";
+                row.Cell(11).Value = "PM Price";
+                row.Cell(12).Value = "Std Cost Price";
+                row.Cell(13).Value = "Cost Price";
+                row.Cell(14).Value = "Sales Price Index";
+            }
+            else
+            {
+                row.Cell(1).Value = dto.Room;
+                row.Cell(2).Value = dto.RofoId;
+                row.Cell(3).Value = dto.ProductId;
+                row.Cell(4).Value = dto.ProductName;
+                row.Cell(5).Value = dto.Unit;
+                row.Cell(6).Value = dto.UnitInKg;
+                row.Cell(7).Value = dto.RofoDate;
+                row.Cell(7).Style.NumberFormat.Format = "dd MMM yyyy";
+                row.Cell(8).Value = dto.QtyRofo;
+                row.Cell(8).Style.NumberFormat.Format = "#,##0.00";
+                row.Cell(9).Value = dto.Yield;
+                row.Cell(9).Style.NumberFormat.Format = "#,##0.0%";
+                row.Cell(10).Value = dto.RmPrice;
+                row.Cell(10).Style.NumberFormat.Format = "#,##0";
+                row.Cell(11).Value = dto.PmPrice;
+                row.Cell(11).Style.NumberFormat.Format = "#,##0";
+                row.Cell(12).Value = dto.StdCostPrice;
+                row.Cell(12).Style.NumberFormat.Format = "#,##0";
+                row.Cell(13).Value = dto.CostPrice;
+                row.Cell(13).Style.NumberFormat.Format = "#,##0";
+                row.Cell(14).Value = dto.SalesPriceIndex;
+                row.Cell(14).Style.NumberFormat.Format = "#,##0";
+                row.Cell(14).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Right;
+            }
+        });
+        
+        // download as excel file
+        return File(result, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"SummaryFgCost_{DateTime.Now:yyyyMMddHHmmss}.xlsx");
+    }
+
+    public async Task<IActionResult> DownloadFgCostDetail([FromQuery] int room)
+    {
+        var response = await _fgCostService.GetFgCostDetailAsync(room);
+
+        if (response is not { IsSuccess: true, Data: not null }) return BadRequest(response.Errors);
+
+        var result = ExcelHelper.ExportExcel(response.Data, (row, dto) =>
+        {
+            if (row.RowNumber() == 1)
+            {
+                row.Cell(1).Value = "Room";
+                row.Cell(2).Value = "Rofo ID";
+                row.Cell(3).Value = "Product ID";
+                row.Cell(4).Value = "Product Name";
+                row.Cell(5).Value = "Rofo Date";
+                row.Cell(6).Value = "Qty Rofo";
+                row.Cell(7).Value = "Item ID";
+                row.Cell(8).Value = "Item Name";
+                row.Cell(9).Value = "Group Substitusi";
+                row.Cell(10).Value = "Item Allocated ID";
+                row.Cell(11).Value = "Item Allocated Name";
+                row.Cell(12).Value = "Batch";
+                row.Cell(13).Value = "Qty";
+                row.Cell(14).Value = "Price";
+                row.Cell(15).Value = "RM Price";
+                row.Cell(16).Value = "PM Price";
+                row.Cell(17).Value = "Std Cost Price";
+                row.Cell(18).Value = "Source";
+                row.Cell(19).Value = "Ref ID";
+                row.Cell(20).Value = "Latest Purchase Price";
+            }
+            else
+            {
+                row.Cell(1).Value = dto.Room;
+                row.Cell(2).Value = dto.RofoId;
+                row.Cell(3).Value = dto.ProductId;
+                row.Cell(4).Value = dto.ProductName;
+                row.Cell(5).Value = dto.RofoDate;
+                row.Cell(5).Style.NumberFormat.Format = "dd MMM yyyy";
+                row.Cell(6).Value = dto.QtyRofo;
+                row.Cell(7).Value = dto.ItemId;
+                row.Cell(8).Value = dto.ItemName;
+                row.Cell(9).Value = dto.GroupSubstitusi;
+                row.Cell(10).Value = dto.ItemAllocatedId;
+                row.Cell(11).Value = dto.ItemAllocatedName;
+                row.Cell(12).Value = dto.InventBatch;
+                row.Cell(13).Value = dto.Qty;
+                row.Cell(14).Value = dto.Price;
+                row.Cell(15).Value = dto.RmPrice;
+                row.Cell(16).Value = dto.PmPrice;
+                row.Cell(17).Value = dto.StdCostPrice;
+                row.Cell(18).Value = dto.Source;
+                row.Cell(19).Value = dto.RefId;
+                row.Cell(20).Value = dto.LatestPurchasePrice;
+            }
+        });
+
+        // download as excel file
+        return File(result, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            $"FgCostDetail_{DateTime.Now:yyyyMMddHHmmss}.xlsx");
+    }
+
+    public async Task<IActionResult> DownloadFgCostDetailsByRofoId([FromQuery] int rofoId)
+    {
+        var response = await _fgCostService.GetFgCostDetailsByRofoIdAsync(rofoId);
+
+        if (response is not { IsSuccess: true, Data: not null }) return BadRequest(response.Errors);
+
+        var result = ExcelHelper.ExportExcel(response.Data, (row, dto) =>
+        {
+            if (row.RowNumber() == 1)
+            {
+                row.Cell(1).Value = "Room";
+                row.Cell(2).Value = "Rofo ID";
+                row.Cell(3).Value = "Product ID";
+                row.Cell(4).Value = "Product Name";
+                row.Cell(5).Value = "Rofo Date";
+                row.Cell(6).Value = "Qty Rofo";
+                row.Cell(7).Value = "Item ID";
+                row.Cell(8).Value = "Item Name";
+                row.Cell(9).Value = "Group Substitusi";
+                row.Cell(10).Value = "Item Allocated ID";
+                row.Cell(11).Value = "Item Allocated Name";
+                row.Cell(12).Value = "Batch";
+                row.Cell(13).Value = "Qty";
+                row.Cell(14).Value = "Price";
+                row.Cell(15).Value = "RM Price";
+                row.Cell(16).Value = "PM Price";
+                row.Cell(17).Value = "Std Cost Price";
+                row.Cell(18).Value = "Source";
+                row.Cell(19).Value = "Ref ID";
+                row.Cell(20).Value = "Latest Purchase Price";
+            }
+            else
+            {
+                row.Cell(1).Value = dto.Room;
+                row.Cell(2).Value = dto.RofoId;
+                row.Cell(3).Value = dto.ProductId;
+                row.Cell(4).Value = dto.ProductName;
+                row.Cell(5).Value = dto.RofoDate;
+                row.Cell(5).Style.NumberFormat.Format = "dd MMM yyyy";
+                row.Cell(6).Value = dto.QtyRofo;
+                row.Cell(7).Value = dto.ItemId;
+                row.Cell(8).Value = dto.ItemName;
+                row.Cell(9).Value = dto.GroupSubstitusi;
+                row.Cell(10).Value = dto.ItemAllocatedId;
+                row.Cell(11).Value = dto.ItemAllocatedName;
+                row.Cell(12).Value = dto.InventBatch;
+                row.Cell(13).Value = dto.Qty;
+                row.Cell(13).Style.NumberFormat.Format = "#,##0.00";
+                row.Cell(14).Value = dto.Price;
+                row.Cell(14).Style.NumberFormat.Format = "#,##0";
+                row.Cell(15).Value = dto.RmPrice;
+                row.Cell(15).Style.NumberFormat.Format = "#,##0";
+                row.Cell(16).Value = dto.PmPrice;
+                row.Cell(16).Style.NumberFormat.Format = "#,##0";
+                row.Cell(17).Value = dto.StdCostPrice;
+                row.Cell(17).Style.NumberFormat.Format = "#,##0";
+                row.Cell(18).Value = dto.Source;
+                row.Cell(19).Value = dto.RefId;
+                row.Cell(20).Value = dto.LatestPurchasePrice;
+                row.Cell(20).Style.NumberFormat.Format = "#,##0";
+            }
+        });
+        
+        // download as excel file
+        return File(result, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            $"FgCostDetailsByRofoId_{DateTime.Now:yyyyMMddHHmmss}.xlsx");
     }
 }
 

--- a/Futurist.Web/Controllers/MupController.cs
+++ b/Futurist.Web/Controllers/MupController.cs
@@ -45,42 +45,155 @@ public class MupController : Controller
 
         var stream = ExcelHelper.ExportExcel(response.Data, (row, dto) =>
         {
-            row.Cell(1).Value = dto.Room;
-            row.Cell(2).Value = dto.ProductId;
-            row.Cell(3).Value = dto.ProductName;
-            
-            row.Cell(4).Value = dto.RofoDate;
-            row.Cell(4).Style.NumberFormat.Format = "dd MMM yyyy";
-            
-            row.Cell(5).Value = dto.QtyRofo;
-            row.Cell(5).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
-            
-            row.Cell(6).Value = dto.ItemId;
-            row.Cell(7).Value = dto.ItemName;
-            row.Cell(8).Value = dto.GroupSubstitusi;
-            row.Cell(9).Value = dto.ItemAllocatedId;
-            row.Cell(10).Value = dto.ItemAllocatedName;
-            row.Cell(11).Value = dto.UnitId;
-            row.Cell(12).Value = dto.InventBatch;
-            
-            row.Cell(13).Value = dto.Qty;
-            row.Cell(13).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Precision2WithSeparatorAndParens;
-            
-            row.Cell(14).Value = dto.Price;
-            row.Cell(14).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
-            
-            row.Cell(15).Value = dto.Source;
-            row.Cell(16).Value = dto.RefId;
-            
-            row.Cell(17).Value = dto.LatestPurchasePrice;
-            row.Cell(17).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
-            
-            row.Cell(18).Value = dto.Gap;
-            row.Cell(18).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+            if (row.RowNumber() == 1)
+            {
+                row.Cell(1).Value = "Room";
+                row.Cell(2).Value = "Product Id";
+                row.Cell(3).Value = "Product Name";
+                row.Cell(4).Value = "Rofo Date";
+                row.Cell(5).Value = "Qty Rofo";
+                row.Cell(6).Value = "Item Id";
+                row.Cell(7).Value = "Item Name";
+                row.Cell(8).Value = "Group Substitusi";
+                row.Cell(9).Value = "Item Allocated Id";
+                row.Cell(10).Value = "Item Allocated Name";
+                row.Cell(11).Value = "Unit Id";
+                row.Cell(12).Value = "Batch";
+                row.Cell(13).Value = "Qty";
+                row.Cell(14).Value = "Price";
+                row.Cell(15).Value = "Source";
+                row.Cell(16).Value = "Ref Id";
+                row.Cell(17).Value = "Latest Purchase Price";
+                row.Cell(18).Value = "Gap";
+            }
+            else
+            {
+                row.Cell(1).Value = dto.Room;
+                row.Cell(2).Value = dto.ProductId;
+                row.Cell(3).Value = dto.ProductName;
+                row.Cell(4).Value = dto.RofoDate;
+                row.Cell(4).Style.NumberFormat.Format = "dd MMM yyyy";
+                row.Cell(5).Value = dto.QtyRofo;
+                row.Cell(5).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+                row.Cell(6).Value = dto.ItemId;
+                row.Cell(7).Value = dto.ItemName;
+                row.Cell(8).Value = dto.GroupSubstitusi;
+                row.Cell(9).Value = dto.ItemAllocatedId;
+                row.Cell(10).Value = dto.ItemAllocatedName;
+                row.Cell(11).Value = dto.UnitId;
+                row.Cell(12).Value = dto.InventBatch;
+                row.Cell(13).Value = dto.Qty;
+                row.Cell(13).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Precision2WithSeparatorAndParens;
+                row.Cell(14).Value = dto.Price;
+                row.Cell(14).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+                row.Cell(15).Value = dto.Source;
+                row.Cell(16).Value = dto.RefId;
+                row.Cell(17).Value = dto.LatestPurchasePrice;
+                row.Cell(17).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+                row.Cell(18).Value = dto.Gap;
+                row.Cell(18).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+            }
         });
         
         // download as excel file
         return File(stream, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"MupResult_{DateTime.Now:yyyyMMddHHmmss}.xlsx");
+    }
+    
+    public async Task<IActionResult> DownloadMupSummaryByItemId([FromQuery] int room)
+    {
+        var listRequestDto = new ListRequestDto
+        {
+            Filters = new Dictionary<string, string>
+            {
+                { "Room", room.ToString() }
+            }
+        };
+        
+        var response = await _mupService.MupSummaryByItemIdAsync(listRequestDto);
+
+        if (response is not { IsSuccess: true, Data: not null }) return BadRequest(response.Errors);
+        
+        var result = ExcelHelper.ExportExcel(response.Data, (row, dto) =>
+        {
+            if (row.RowNumber() == 1)
+            {
+                row.Cell(1).Value = "Mup Date";
+                row.Cell(2).Value = "Group Substitusi";
+                row.Cell(3).Value = "Item Id";
+                row.Cell(4).Value = "Item Name";
+                row.Cell(5).Value = "Qty";
+                row.Cell(6).Value = "Price";
+            }
+            else
+            {
+                row.Cell(1).Value = dto.MupDate;
+                row.Cell(1).Style.NumberFormat.Format = "dd MMM yyyy";
+                row.Cell(2).Value = dto.GroupSubstitusi;
+                row.Cell(3).Value = dto.ItemId;
+                row.Cell(4).Value = dto.ItemName;
+                row.Cell(5).Value = dto.Qty;
+                row.Cell(5).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Precision2WithSeparatorAndParens;
+                row.Cell(6).Value = dto.Price;
+                row.Cell(6).Style.NumberFormat.Format = "#,##0";
+            }
+        });
+        
+        // download as excel file
+        return File(result, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"MupSummaryByItemId_{DateTime.Now:yyyyMMddHHmmss}.xlsx");
+    }
+
+    public async Task<IActionResult> DownloadMupSummaryByBatchNumber([FromQuery] int room)
+    {
+        var listRequestDto = new ListRequestDto
+        {
+            Filters = new Dictionary<string, string>
+            {
+                { "Room", room.ToString() }
+            }
+        };
+        
+        var response = await _mupService.MupSummaryByBatchNumberAsync(listRequestDto);
+        
+        if (response is not { IsSuccess: true, Data: not null }) return BadRequest(response.Errors);
+        
+        var stream = ExcelHelper.ExportExcel(response.Data, (row, dto) =>
+        {
+            if (row.RowNumber() == 1)
+            {
+                row.Cell(1).Value = "MUP Date";
+                row.Cell(2).Value = "Source";
+                row.Cell(3).Value = "Group Substitusi";
+                row.Cell(4).Value = "Item Allocated ID";
+                row.Cell(5).Value = "Item Allocated Name";
+                row.Cell(6).Value = "Unit";
+                row.Cell(7).Value = "Batch";
+                row.Cell(8).Value = "Qty";
+                row.Cell(9).Value = "Price";
+                row.Cell(10).Value = "Latest Purchase Price";
+                row.Cell(11).Value = "Gap";
+            }
+            else
+            {
+                row.Cell(1).Value = dto.MupDate;
+                row.Cell(2).Value = dto.Source;
+                row.Cell(3).Value = dto.GroupSubstitusi;
+                row.Cell(4).Value = dto.ItemAllocatedId;
+                row.Cell(5).Value = dto.ItemAllocatedName;
+                row.Cell(6).Value = dto.UnitId;
+                row.Cell(7).Value = dto.InventBatch;
+                row.Cell(8).Value = dto.Qty;
+                row.Cell(8).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Precision2WithSeparatorAndParens;
+                row.Cell(9).Value = dto.Price;
+                row.Cell(9).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+                row.Cell(10).Value = dto.LatestPurchasePrice;
+                row.Cell(10).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+                row.Cell(11).Value = dto.Gap;
+                row.Cell(11).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+            }
+        });
+        
+        // download as excel file
+        return File(stream, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"MupSummaryByBatchNumber_{DateTime.Now:yyyyMMddHHmmss}.xlsx");
     }
 }
 


### PR DESCRIPTION
This pull request includes several enhancements and additions to the Excel export functionality and introduces new endpoints for downloading various summaries and details in Excel format. The most important changes include updates to the `ExcelHelper` class, modifications to existing controller actions, and the addition of new controller actions for exporting data.

### Enhancements to `ExcelHelper` class:

* Added a new constraint to the `ExportExcel` method to require `T` to have a parameterless constructor.
* Simplified the header initialization in the `ExportExcel` method by using the `mapRow` function.
* Introduced a new method `CreateExcelTemplate` to generate Excel templates with custom headers.

### Modifications to existing controller actions:

* Updated `DownloadBomErrorCheck` in `BomStdController` to include header initialization within the `mapRow` function.
* Updated `DownloadMupResult` in `MupController` to include header initialization within the `mapRow` function.

### New controller actions for exporting data:

* Added `DownloadSummaryFgCost`, `DownloadFgCostDetail`, and `DownloadFgCostDetailsByRofoId` actions in `FgCostController` to export various FG cost summaries and details.
* Added `DownloadMupSummaryByItemId` and `DownloadMupSummaryByBatchNumber` actions in `MupController` to export MUP summaries by item ID and batch number.