### PR TITLE
feat: Implement job logging with Serilog and Hangfire integration

### DIFF
--- a/Futurist.Service.Interface/Futurist.Service.Interface.csproj
+++ b/Futurist.Service.Interface/Futurist.Service.Interface.csproj
@@ -10,4 +10,8 @@
       <ProjectReference Include="..\Futurist.Service.Dto\Futurist.Service.Dto.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Hangfire.Core" Version="1.8.18" />
+    </ItemGroup>
+
 </Project>

--- a/Futurist.Web/Futurist.Web.csproj
+++ b/Futurist.Web/Futurist.Web.csproj
@@ -25,6 +25,7 @@
       </PackageReference>
       <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
       <PackageReference Include="Serilog" Version="4.2.0" />
+      <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
       <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="8.1.0" />
     </ItemGroup>
 

--- a/Futurist.Web/Hangfire/JobLoggerAttribute.cs
+++ b/Futurist.Web/Hangfire/JobLoggerAttribute.cs
@@ -1,0 +1,60 @@
+using Futurist.Service.Dto;
+using Futurist.Service.Dto.Common;
+using Hangfire.Common;
+using Hangfire.Server;
+using Hangfire.States;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace Futurist.Web.Hangfire;
+
+public class JobLoggerAttribute : JobFilterAttribute, IElectStateFilter, IServerFilter
+{
+    private readonly ILogger _logger = Log.ForContext<JobLoggerAttribute>();
+
+    public void OnStateElection(ElectStateContext context)
+    {
+        if (context.BackgroundJob.Job.Method.Name.Contains("Notify"))
+            return;
+
+        if (context.CandidateState is EnqueuedState)
+        {
+            _logger.Information("Job {JobId} with method {MethodName} has been {Status}", context.BackgroundJob.Id, context.BackgroundJob.Job.Method.Name, "Enqueued");
+        }
+    }
+
+    public void OnPerforming(PerformingContext context)
+    {
+        // No implementation needed
+    }
+
+    public void OnPerformed(PerformedContext context)
+    {
+        // Skip logging for notification jobs
+        if (context.BackgroundJob.Job.Method.Name.Contains("Notify"))
+            return;
+
+        var methodName = context.BackgroundJob.Job.Method.Name;
+        var roomId = context.BackgroundJob.Job.Args[0];
+
+        switch (context.Result)
+        {
+            case ServiceResponse<SpTaskDto> resultTaskSp when context.Exception != null:
+                _logger.Error(context.Exception, "JobId: {JobId}, {MethodName} with Room {RoomId} {Status}, Result: {Result}", context.BackgroundJob.Id, methodName, roomId, "Failed", string.Join(", ", resultTaskSp.Errors));
+                break;
+            // map the context.Result to a dictionary
+            case ServiceResponse<SpTaskDto> { Data.StatusId: false } resultTaskSp:
+                _logger.Error("JobId: {JobId}, {MethodName} with Room {RoomId} {Status}, Result: {Result}", context.BackgroundJob.Id, methodName, roomId, "Failed", resultTaskSp.Data?.StatusName);
+                break;
+            case ServiceResponse<SpTaskDto> resultTaskSp:
+                _logger.Information("JobId: {JobId}, {MethodName} with Room {RoomId} {Status}, Result: {Result}", context.BackgroundJob.Id, methodName, roomId, "Succeeded", resultTaskSp.Data?.StatusName);
+                break;
+            case ServiceResponse<string> resultString when context.Exception != null:
+                _logger.Error(context.Exception, "JobId: {JobId}, {MethodName} with Room {RoomId} {Status}, Result: {Result}", context.BackgroundJob.Id, methodName, roomId, "Failed", resultString.Errors);
+                break;
+            case ServiceResponse<string> resultString:
+                _logger.Information("JobId: {JobId}, {MethodName} with Room {RoomId} {Status}, Result: {Result}", context.BackgroundJob.Id, methodName, roomId, "Succeeded", resultString.Data);
+                break;
+        }
+    }
+}

--- a/Futurist.Web/appsettings.json
+++ b/Futurist.Web/appsettings.json
@@ -1,9 +1,13 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "AllowedHosts": "*",
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     }
   },
-  "AllowedHosts": "*"
+  "ConnectionTimeout": 18000
 }


### PR DESCRIPTION
This pull request includes several changes to the `Futurist` project, focusing on adding logging capabilities with Serilog and integrating Hangfire for background job processing. The most important changes involve updating project files to include necessary package references, implementing a custom job logger attribute for Hangfire, and configuring Serilog in the application.

### Logging and Background Job Processing Enhancements:

* [`Futurist.Service.Interface/Futurist.Service.Interface.csproj`](diffhunk://#diff-26e773b0148ced69cec4da007be92f49b4ac8c1442c9c48a551aedc011993f3cR13-R16): Added a reference to the `Hangfire.Core` package to support background job processing.
* [`Futurist.Web/Futurist.Web.csproj`](diffhunk://#diff-bdb10d7a14f6df71ac2fbb01582399b89e1f10e01f5d82f1132f0f721eabebafR28): Added a reference to the `Serilog.AspNetCore` package to enhance logging capabilities within ASP.NET Core applications.
* [`Futurist.Web/Hangfire/JobLoggerAttribute.cs`](diffhunk://#diff-622ee23935da64b5e32b76133af0a2119e76d72360a1f8be146271d15c54735aR1-R60): Implemented a `JobLoggerAttribute` class to log the state and performance of Hangfire jobs, including handling different job result scenarios and logging errors.

### Configuration Updates:

* [`Futurist.Web/Program.cs`](diffhunk://#diff-e094c37c8badac832f70856e34d53dcd14f9813eaffeff5bbba2ce9e8b8a9949R1-R76): Configured Serilog for logging, including setting up different sinks for general logs and job-specific logs, and added a global filter for Hangfire jobs using the `JobLoggerAttribute`.
* [`Futurist.Web/appsettings.json`](diffhunk://#diff-554c3da8f4e53298f7d289c10bae932701cdd221674fc7cc2e5da66fd7348b7aL2-R12): Updated the logging configuration to use Serilog with specific minimum levels and overrides for different namespaces, and added a connection timeout setting.