### PR TITLE
feat(BomStd): Update command and repository methods to include timeout and change return types

### DIFF
--- a/Futurist.Repository.Command/BomStdCommand/BomErrorCheckPagedListCommand.cs
+++ b/Futurist.Repository.Command/BomStdCommand/BomErrorCheckPagedListCommand.cs
@@ -1,9 +1,8 @@
-﻿using Futurist.Domain;
-using Futurist.Domain.Common;
+﻿using Futurist.Domain.Common;
 
 namespace Futurist.Repository.Command.BomStdCommand;
 
 public class BomErrorCheckPagedListCommand : BaseCommand
 {
-    public PagedListRequest<BomStd> PagedListRequest { get; init; } = new();
+    public PagedListRequest PagedListRequest { get; init; } = new();
 }

--- a/Futurist.Repository.Command/BomStdCommand/ProcessBomStdCommand.cs
+++ b/Futurist.Repository.Command/BomStdCommand/ProcessBomStdCommand.cs
@@ -3,4 +3,5 @@
 public class ProcessBomStdCommand : BaseCommand
 {
     public int RoomId { get; init; }
+    public int Timeout { get; init; }
 }

--- a/Futurist.Repository.Interface/IBomStdRepository.cs
+++ b/Futurist.Repository.Interface/IBomStdRepository.cs
@@ -8,7 +8,7 @@ namespace Futurist.Repository.Interface;
 
 public interface IBomStdRepository
 {
-    Task<string?> ProcessBomStdAsync(ProcessBomStdCommand command);
+    Task<SpTask?> ProcessBomStdAsync(ProcessBomStdCommand command);
     Task<IEnumerable<BomStd>> BomErrorCheckAsync(BomErrorCheckCommand command);
     Task<PagedList<BomStd>> BomErrorCheckPagedListAsync(BomErrorCheckPagedListCommand command);
     Task<IEnumerable<int>> GetBomStdRoomIdsAsync(GetBomStdRoomIdsCommand command);

--- a/Futurist.Repository.SqlServer/BomStdRepository.cs
+++ b/Futurist.Repository.SqlServer/BomStdRepository.cs
@@ -17,12 +17,12 @@ public class BomStdRepository : IBomStdRepository
         _sqlConnection = sqlConnection;
     }
 
-    public async Task<string?> ProcessBomStdAsync(ProcessBomStdCommand command)
+    public async Task<SpTask?> ProcessBomStdAsync(ProcessBomStdCommand command)
     {
         const string query = "EXEC CogsProjection.dbo.BomStd_insert @Room";
         await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
-        return await _sqlConnection.ExecuteScalarAsync<string>(query, new { Room = command.RoomId },
-            transaction: command.DbTransaction);
+        return await _sqlConnection.QuerySingleOrDefaultAsync<SpTask>(query, new { Room = command.RoomId },
+            transaction: command.DbTransaction, commandTimeout: command.Timeout);
     }
 
     public async Task<IEnumerable<BomStd>> BomErrorCheckAsync(BomErrorCheckCommand command)


### PR DESCRIPTION
This pull request includes several changes to the `Futurist.Repository` project, focusing on updating command classes, modifying repository interfaces, and adjusting SQL query execution. The most important changes include removing unnecessary generic type parameters, adding a new property to a command class, and updating method return types and SQL execution parameters.

Command class updates:

* [`Futurist.Repository.Command/BomStdCommand/BomErrorCheckPagedListCommand.cs`](diffhunk://#diff-1402279afb8cfd2fc4f2c03294fe2791b6d42c78e8d07a8900a2ea491d984fc6L1-R7): Removed the unnecessary generic type parameter from `PagedListRequest`.
* [`Futurist.Repository.Command/BomStdCommand/ProcessBomStdCommand.cs`](diffhunk://#diff-06c052b949629c293c0f951b494677ac2eae54f72695595f6cd3261ab3fee486R6): Added a new `Timeout` property to the `ProcessBomStdCommand` class.

Repository interface updates:

* [`Futurist.Repository.Interface/IBomStdRepository.cs`](diffhunk://#diff-1df8fee756503595688aff8b9ff36f15622cbe250efa81e895635885f8ab94e5L11-R11): Changed the return type of `ProcessBomStdAsync` from `Task<string?>` to `Task<SpTask?>`.

SQL execution adjustments:

* [`Futurist.Repository.SqlServer/BomStdRepository.cs`](diffhunk://#diff-5e1479b8855e2d4f4dd8ec4f7c676d4515382d66db21a1ea6483aa4879483e4eL20-R25): Updated the `ProcessBomStdAsync` method to use the new `Timeout` property and changed the return type to `SpTask`.