### PR TITLE
feat(ExchangeRate): Add commands and repository interface for managing exchange rates

### DIFF
--- a/Futurist.Repository.Command/ExchangeRateCommand/BulkInsertExchangeRateCommand.cs
+++ b/Futurist.Repository.Command/ExchangeRateCommand/BulkInsertExchangeRateCommand.cs
@@ -1,0 +1,8 @@
+﻿using Futurist.Domain;
+
+namespace Futurist.Repository.Command.ExchangeRateCommand;
+
+public class BulkInsertExchangeRateCommand : BaseCommand
+{
+    public IEnumerable<ExchangeRateSp> ExchangeRates { get; set; } = new List<ExchangeRateSp>();
+}

--- a/Futurist.Repository.Command/ExchangeRateCommand/DeleteExchangeRateCommand.cs
+++ b/Futurist.Repository.Command/ExchangeRateCommand/DeleteExchangeRateCommand.cs
@@ -1,0 +1,10 @@
+﻿using Futurist.Domain;
+
+namespace Futurist.Repository.Command.ExchangeRateCommand;
+
+public class DeleteExchangeRateCommand : BaseCommand
+{
+    public string CurrencyCode { get; set; } = string.Empty;
+    public DateTime ValidFrom { get; set; }
+    public DateTime ValidTo { get; set; }
+}

--- a/Futurist.Repository.Command/ExchangeRateCommand/GetExchangeRateCommand.cs
+++ b/Futurist.Repository.Command/ExchangeRateCommand/GetExchangeRateCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace Futurist.Repository.Command.ExchangeRateCommand;
+
+public class GetExchangeRateCommand : BaseCommand
+{
+    public string CurrencyCode { get; set; } = string.Empty;
+    public DateTime ValidFrom { get; set; }
+    public DateTime ValidTo { get; set; }
+}

--- a/Futurist.Repository.Command/ExchangeRateCommand/GetExchangeRatePagedListCommand.cs
+++ b/Futurist.Repository.Command/ExchangeRateCommand/GetExchangeRatePagedListCommand.cs
@@ -1,0 +1,8 @@
+﻿using Futurist.Domain.Common;
+
+namespace Futurist.Repository.Command.ExchangeRateCommand;
+
+public class GetExchangeRatePagedListCommand : BaseCommand
+{
+    public PagedListRequest PagedListRequest { get; set; } = new();
+}

--- a/Futurist.Repository.Interface/IExchangeRateRepository.cs
+++ b/Futurist.Repository.Interface/IExchangeRateRepository.cs
@@ -1,0 +1,14 @@
+﻿using Futurist.Domain;
+using Futurist.Domain.Common;
+using Futurist.Repository.Command.ExchangeRateCommand;
+
+namespace Futurist.Repository.Interface;
+
+public interface IExchangeRateRepository
+{
+    Task BulkInsertExchangeRateAsync(BulkInsertExchangeRateCommand command);
+    
+    Task<PagedList<ExchangeRateSp>> GetExchangeRatePagedListAsync(GetExchangeRatePagedListCommand command);
+    Task<ExchangeRateSp?> GetExchangeRateAsync(GetExchangeRateCommand command);
+    Task DeleteExchangeRateAsync(DeleteExchangeRateCommand command);
+}

--- a/Futurist.Repository.SqlServer/ExchangeRateRepository.cs
+++ b/Futurist.Repository.SqlServer/ExchangeRateRepository.cs
@@ -1,0 +1,147 @@
+﻿using System.Data;
+using Dapper;
+using Futurist.Common.Helpers;
+using Futurist.Domain;
+using Futurist.Domain.Common;
+using Futurist.Repository.Command.ExchangeRateCommand;
+using Futurist.Repository.Interface;
+using Microsoft.Data.SqlClient;
+
+namespace Futurist.Repository.SqlServer;
+
+public class ExchangeRateRepository : IExchangeRateRepository
+{
+    private readonly IDbConnection _sqlConnection;
+
+    public ExchangeRateRepository(IDbConnection sqlConnection)
+    {
+        _sqlConnection = sqlConnection;
+    }
+
+    public async Task BulkInsertExchangeRateAsync(BulkInsertExchangeRateCommand command)
+    {
+        // insert new rofo
+        var sqlServerConnection = _sqlConnection as SqlConnection ?? throw new InvalidOperationException("Invalid SQL connection");
+        
+        using var sqlBulkCopy = command.DbTransaction is SqlTransaction sqlServerTransaction ? new SqlBulkCopy(sqlServerConnection, SqlBulkCopyOptions.Default, sqlServerTransaction) : new SqlBulkCopy(sqlServerConnection);
+        
+        sqlBulkCopy.DestinationTableName = "ExchangeRate";
+        sqlBulkCopy.BatchSize = 1000;
+
+        var dataTable = new DataTable();
+        dataTable.Columns.Add("CurrencyCode", typeof(string));
+        dataTable.Columns.Add("ValidFrom", typeof(DateTime));
+        dataTable.Columns.Add("ValidTo", typeof(DateTime));
+        dataTable.Columns.Add("ExchangeRate", typeof(decimal));
+        dataTable.Columns.Add("CreatedBy", typeof(decimal));
+        dataTable.Columns.Add("CreatedDate", typeof(DateTime));
+        
+        foreach (var item in command.ExchangeRates)
+        {
+            dataTable.Rows.Add(item.CurrencyCode, item.ValidFrom, item.ValidTo, item.ExchangeRate, item.CreatedBy, item.CreatedDate);
+        }
+        
+        await sqlBulkCopy.WriteToServerAsync(dataTable);
+    }
+
+    public async Task<PagedList<ExchangeRateSp>> GetExchangeRatePagedListAsync(GetExchangeRatePagedListCommand command)
+    {
+        const string query = """
+                             SELECT [CurrencyCode]
+                             	,[ValidFrom]
+                             	,[ValidTo]
+                             	,[ExchangeRate]
+                             FROM [ExchangeRate]
+                             /**where**/
+                             /**orderby**/
+                             OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY
+                             """;
+        
+        const string queryCount = """
+                                  SELECT COUNT(*)
+                                  FROM [ExchangeRate]
+                                  /**where**/
+                                  """;
+        
+        var pagedListRequest = command.PagedListRequest;
+
+        var sqlBuilder = new SqlBuilder();
+        
+        if (pagedListRequest.Filters.TryGetValue(nameof(ExchangeRateSp.CurrencyCode), out var currencyCodeFilter))
+        {
+            if (currencyCodeFilter.Contains('*') || currencyCodeFilter.Contains('%'))
+            {
+                currencyCodeFilter = currencyCodeFilter.Replace('*', '%');
+                sqlBuilder.Where($"CurrencyCode LIKE @CurrencyCode", new { CurrencyCode = currencyCodeFilter });
+            }
+            else
+            {
+                sqlBuilder.Where($"CurrencyCode = @CurrencyCode", new { CurrencyCode = currencyCodeFilter });
+            }
+        }
+        
+        if (pagedListRequest.Filters.TryGetValue(nameof(ExchangeRateSp.ValidFrom), out var validFromFilter) && DateTime.TryParse(validFromFilter, out var validFrom))
+        {
+            sqlBuilder.Where($"ValidFrom = @ValidFrom", new { ValidFrom = validFrom });
+        }
+        
+        if (pagedListRequest.Filters.TryGetValue(nameof(ExchangeRateSp.ValidTo), out var validToFilter) && DateTime.TryParse(validToFilter, out var validTo))
+        {
+            sqlBuilder.Where($"ValidTo = @ValidTo", new { ValidTo = validTo });
+        }
+        
+        if (pagedListRequest.Filters.TryGetValue(nameof(ExchangeRateSp.ExchangeRate), out var exchangeRateFilter))
+        {
+            if (decimal.TryParse(exchangeRateFilter, out var exchangeRate))
+            {
+                sqlBuilder.Where($"ExchangeRate = @ExchangeRate", new { ExchangeRate = exchangeRate });
+            }
+            else
+            {
+                var match = RegexHelper.LogicalOperatorRegex().Match(exchangeRateFilter);
+                if (match.Success)
+                {
+                    sqlBuilder.Where($"ExchangeRate {match.Groups[1].Value} @ExchangeRate", new { ExchangeRate = match.Groups[2].Value });
+                }
+            }
+        }
+        
+        var sort = pagedListRequest.IsSortAscending ? "ASC" : "DESC";
+        sqlBuilder.OrderBy(string.IsNullOrEmpty(pagedListRequest.SortBy)
+            ? $"RecId {sort}"
+            : $"{pagedListRequest.SortBy} {sort}");
+        
+        sqlBuilder.AddParameters(new
+            { Offset = (pagedListRequest.PageNumber - 1) * pagedListRequest.PageSize, pagedListRequest.PageSize });
+        
+        var queryTemplate = sqlBuilder.AddTemplate(query);
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        var exchangeRates = await _sqlConnection.QueryAsync<ExchangeRateSp>(queryTemplate.RawSql, queryTemplate.Parameters, command.DbTransaction);
+        queryTemplate = sqlBuilder.AddTemplate(queryCount);
+        var exchangeRateCount = await _sqlConnection.ExecuteScalarAsync<int>(queryTemplate.RawSql, queryTemplate.Parameters, command.DbTransaction);
+        return new PagedList<ExchangeRateSp>(exchangeRates, pagedListRequest.PageNumber, pagedListRequest.PageSize, exchangeRateCount);
+    }
+
+    public async Task<ExchangeRateSp?> GetExchangeRateAsync(GetExchangeRateCommand command)
+    {
+        const string query = """
+                             SELECT [CurrencyCode]
+                             	,[ValidFrom]
+                             	,[ValidTo]
+                             	,[ExchangeRate]
+                             FROM [ExchangeRate]
+                             WHERE [CurrencyCode] = @CurrencyCode AND [ValidFrom] = @ValidFrom AND [ValidTo] = @ValidTo;
+                             """;
+        
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        return await _sqlConnection.QueryFirstOrDefaultAsync<ExchangeRateSp>(query, new { command.CurrencyCode, command.ValidFrom, command.ValidTo }, command.DbTransaction);
+    }
+
+    public async Task DeleteExchangeRateAsync(DeleteExchangeRateCommand command)
+    {
+        const string query = "DELETE FROM [ExchangeRate] WHERE [CurrencyCode] = @CurrencyCode AND [ValidFrom] = @ValidFrom";
+        
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        await _sqlConnection.ExecuteAsync(query, new { command.CurrencyCode, command.ValidFrom, command.ValidTo }, command.DbTransaction);
+    }
+}


### PR DESCRIPTION
This pull request introduces several new commands and repository methods to handle exchange rate operations in the `Futurist.Repository` project. The primary changes include the addition of new command classes for bulk insert, delete, get, and paged list operations and their implementation in the repository interface and its SQL Server implementation.

New command classes:

* [`BulkInsertExchangeRateCommand`](diffhunk://#diff-bae5bd0084509edc53f3c43c8eb59ee27d3ac320195d6c8436d13a7303c9745fR1-R8): Added to handle bulk insertion of exchange rates.
* [`DeleteExchangeRateCommand`](diffhunk://#diff-21c5ef725b3fff8062acdd4ae4bc57fbb1ab0d9063f95df0e262e809dbb67cbbR1-R10): Added to handle the deletion of exchange rates based on currency code and validity period.
* [`GetExchangeRateCommand`](diffhunk://#diff-1967affa692fbf127cc330ef263aa4576bf39d8e1207bbb81afa05d77be81b89R1-R8): Added to retrieve a specific exchange rate based on currency code and validity period.
* [`GetExchangeRatePagedListCommand`](diffhunk://#diff-7b93219fc3c588bbb53fbb494a4eca9e2138a0a2eccc9a1e5763a3c175db4326R1-R8): Added to retrieve a paginated list of exchange rates with filtering and sorting capabilities.

Repository interface and implementation:

* [`IExchangeRateRepository`](diffhunk://#diff-23fadc5973ebcde7347854355b55bb4dc374781ec175ac18eb22f6a740b75dd2R1-R14): Added methods for bulk insertion, retrieval of a single exchange rate, retrieval of a paginated list of exchange rates, and deletion of exchange rates.
* [`ExchangeRateRepository`](diffhunk://#diff-eb80cb374b84e783d2be70bd5d524575f6c42578d31755003480464e84ccf22eR1-R147): Implemented the methods defined in `IExchangeRateRepository` using Dapper and SQL Server-specific logic.