### PR TITLE
feat(FgCost): Add timeout property to CalculateFgCostCommand and update related repository methods

### DIFF
--- a/Futurist.Repository.Command/FgCostCommand/CalculateFgCostCommand.cs
+++ b/Futurist.Repository.Command/FgCostCommand/CalculateFgCostCommand.cs
@@ -3,4 +3,5 @@
 public class CalculateFgCostCommand : BaseCommand
 {
     public int RoomId { get; init; }
+    public int Timeout { get; init; }
 }

--- a/Futurist.Repository.Command/FgCostCommand/GetFgCostDetailPagedListCommand.cs
+++ b/Futurist.Repository.Command/FgCostCommand/GetFgCostDetailPagedListCommand.cs
@@ -1,9 +1,8 @@
-﻿using Futurist.Domain;
-using Futurist.Domain.Common;
+﻿using Futurist.Domain.Common;
 
 namespace Futurist.Repository.Command.FgCostCommand;
 
 public class GetFgCostDetailPagedListCommand : BaseCommand
 {
-    public PagedListRequest<FgCostDetailSp> PagedListRequest { get; init; } = new();
+    public PagedListRequest PagedListRequest { get; init; } = new();
 }

--- a/Futurist.Repository.Command/FgCostCommand/GetFgCostDetailsByRofoIdPagedListCommand.cs
+++ b/Futurist.Repository.Command/FgCostCommand/GetFgCostDetailsByRofoIdPagedListCommand.cs
@@ -1,9 +1,8 @@
-﻿using Futurist.Domain;
-using Futurist.Domain.Common;
+﻿using Futurist.Domain.Common;
 
 namespace Futurist.Repository.Command.FgCostCommand;
 
 public class GetFgCostDetailsByRofoIdPagedListCommand : BaseCommand
 {
-    public PagedListRequest<FgCostDetailSp> PagedListRequest { get; set; } = new();
+    public PagedListRequest PagedListRequest { get; set; } = new();
 }

--- a/Futurist.Repository.Command/FgCostCommand/GetSummaryFgCostPagedListCommand.cs
+++ b/Futurist.Repository.Command/FgCostCommand/GetSummaryFgCostPagedListCommand.cs
@@ -1,9 +1,8 @@
-﻿using Futurist.Domain;
-using Futurist.Domain.Common;
+﻿using Futurist.Domain.Common;
 
 namespace Futurist.Repository.Command.FgCostCommand;
 
 public class GetSummaryFgCostPagedListCommand : BaseCommand
 {
-    public PagedListRequest<FgCostSp> PagedListRequest { get; init; } = new();
+    public PagedListRequest PagedListRequest { get; init; } = new();
 }

--- a/Futurist.Repository.Interface/IFgCostRepository.cs
+++ b/Futurist.Repository.Interface/IFgCostRepository.cs
@@ -6,7 +6,7 @@ namespace Futurist.Repository.Interface;
 
 public interface IFgCostRepository
 {
-    public Task<string?> CalculateFgCostAsync(CalculateFgCostCommand command);
+    public Task<SpTask?> CalculateFgCostAsync(CalculateFgCostCommand command);
     public Task<IEnumerable<FgCostSp>> GetSummaryFgCostAsync(GetSummaryFgCostCommand command);
     public Task<PagedList<FgCostSp>> GetSummaryFgCostPagedListAsync(GetSummaryFgCostPagedListCommand command);
     public Task<IEnumerable<int>> GetFgCostRoomIdsAsync(GetFgCostRoomIdsCommand command);


### PR DESCRIPTION
This pull request includes several changes to the `Futurist.Repository.Command` and `Futurist.Repository.SqlServer` files, mainly focusing on updating the `PagedListRequest` type and improving the SQL execution with `SET ARITHABORT ON`. Additionally, there are changes to the `IFgCostRepository` interface and the `FgCostRepository` class to handle new return types and enhance SQL queries.

**Changes to Commands and PagedListRequest:**

* [`Futurist.Repository.Command/FgCostCommand/CalculateFgCostCommand.cs`](diffhunk://#diff-89abf8ec17b61e699f6d8656ce26a58c8fc78af43a7766989bb1950f22146334R6): Added a new `Timeout` property to the `CalculateFgCostCommand` class.
* `Futurist.Repository.Command/FgCostCommand/GetFgCostDetailPagedListCommand.cs`, `GetFgCostDetailsByRofoIdPagedListCommand.cs`, `GetSummaryFgCostPagedListCommand.cs`: Removed the generic type parameter from `PagedListRequest`. [[1]](diffhunk://#diff-54d8a8e4c6390492a89e7383c4b209aae77a5780c70715c13294b50b9ca43525L1-R7) [[2]](diffhunk://#diff-2605af908fba872dcb603686396b53c286f1c5a8840213ac884f4ea6fa2919f3L1-R7) [[3]](diffhunk://#diff-fa3924e2090e5a913517228e70d50f2bf1a6b0aa0b7627873fe0241fd2a44a53L1-R7)

**Changes to Repository Interface:**

* [`Futurist.Repository.Interface/IFgCostRepository.cs`](diffhunk://#diff-de745f52aec9fe0ffb71b4dd8ab4e121054302e8a6db66668a22828afac0f503L9-R9): Changed the return type of `CalculateFgCostAsync` from `Task<string?>` to `Task<SpTask?>`.

**Changes to FgCostRepository Implementation:**

* [`Futurist.Repository.SqlServer/FgCostRepository.cs`](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12L20-R32): Updated `CalculateFgCostAsync` to execute `SET ARITHABORT ON` and changed the return type to `SpTask`.
* Added `SET ARITHABORT ON` execution in various methods to ensure proper SQL execution settings: `GetSummaryFgCostAsync`, `GetFgCostRoomIdsAsync`, `GetFgCostDetailsAsync`, and others. [[1]](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12R52-R66) [[2]](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12R76-R87) [[3]](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12L263-R298) [[4]](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12R665) [[5]](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12R993)

**SQL Query Enhancements:**

* Enhanced SQL queries to include additional joins and fields, such as adding `SalesPriceIndex` from the `SalesPrice` table. [[1]](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12R52-R66) [[2]](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12R76-R87)
* Modified the default sorting logic for paged list requests to sort by `RofoDate` and `QtyRofo`.

These changes collectively improve the robustness and functionality of the repository commands and SQL execution within the `FgCostRepository` class.