### PR TITLE
feat(Mup): Add new commands for batch number and item ID summaries, and update MupResultPagedListCommand

### DIFF
--- a/Futurist.Repository.Command/MupCommand/MupResultPagedListCommand.cs
+++ b/Futurist.Repository.Command/MupCommand/MupResultPagedListCommand.cs
@@ -1,9 +1,8 @@
-﻿using Futurist.Domain;
-using Futurist.Domain.Common;
+﻿using Futurist.Domain.Common;
 
 namespace Futurist.Repository.Command.MupCommand;
 
 public class MupResultPagedListCommand : BaseCommand
 {
-    public PagedListRequest<MupSp> PagedListRequest { get; init; } = new();
+    public PagedListRequest PagedListRequest { get; init; } = new();
 }

--- a/Futurist.Repository.Command/MupCommand/MupSummaryByBatchNumberCommand.cs
+++ b/Futurist.Repository.Command/MupCommand/MupSummaryByBatchNumberCommand.cs
@@ -1,0 +1,8 @@
+﻿using Futurist.Domain.Common;
+
+namespace Futurist.Repository.Command.MupCommand;
+
+public class MupSummaryByBatchNumberCommand : BaseCommand
+{
+    public ListRequest ListRequest { get; set; } = new();
+}

--- a/Futurist.Repository.Command/MupCommand/MupSummaryByBatchNumberPagedListCommand.cs
+++ b/Futurist.Repository.Command/MupCommand/MupSummaryByBatchNumberPagedListCommand.cs
@@ -1,0 +1,8 @@
+﻿using Futurist.Domain.Common;
+
+namespace Futurist.Repository.Command.MupCommand;
+
+public class MupSummaryByBatchNumberPagedListCommand : BaseCommand
+{
+    public PagedListRequest PagedListRequest { get; set; } = new();
+}

--- a/Futurist.Repository.Command/MupCommand/MupSummaryByItemIdCommand.cs
+++ b/Futurist.Repository.Command/MupCommand/MupSummaryByItemIdCommand.cs
@@ -1,0 +1,8 @@
+﻿using Futurist.Domain.Common;
+
+namespace Futurist.Repository.Command.MupCommand;
+
+public class MupSummaryByItemIdCommand : BaseCommand
+{
+    public ListRequest ListRequest { get; set; } = new();
+}

--- a/Futurist.Repository.Command/MupCommand/MupSummaryByItemIdPagedListCommand.cs
+++ b/Futurist.Repository.Command/MupCommand/MupSummaryByItemIdPagedListCommand.cs
@@ -1,0 +1,8 @@
+﻿using Futurist.Domain.Common;
+
+namespace Futurist.Repository.Command.MupCommand;
+
+public class MupSummaryByItemIdPagedListCommand : BaseCommand
+{
+    public PagedListRequest PagedListRequest { get; set; } = new();
+}

--- a/Futurist.Repository.Interface/IMupRepository.cs
+++ b/Futurist.Repository.Interface/IMupRepository.cs
@@ -7,8 +7,12 @@ namespace Futurist.Repository.Interface;
 
 public interface IMupRepository
 {
-    Task<IEnumerable<MupSp>> ProcessMupAsync(ProcessMupCommand command);
+    Task<SpTask?> ProcessMupAsync(ProcessMupCommand command);
     Task<IEnumerable<MupSp>> MupResultAsync(MupResultCommand command);
     Task<PagedList<MupSp>> MupResultPagedListAsync(MupResultPagedListCommand command);
+    Task<IEnumerable<MupSp>> MupSummaryByItemIdAsync(MupSummaryByItemIdCommand command);
+    Task<PagedList<MupSp>> MupSummaryByItemIdPagedListAsync(MupSummaryByItemIdPagedListCommand command);
+    Task<IEnumerable<MupSp>> MupSummaryByBatchNumberAsync(MupSummaryByBatchNumberCommand command);
+    Task<PagedList<MupSp>> MupSummaryByBatchNumberPagedListAsync(MupSummaryByBatchNumberPagedListCommand command);
     Task<IEnumerable<int>> GetMupRoomIdsAsync(GetMupRoomIdsCommand command);
 }


### PR DESCRIPTION
This pull request introduces several new commands and modifies existing ones in the `Futurist.Repository.Command` namespace to enhance functionality related to Mup summaries and results. Additionally, there are updates to the `IMupRepository` interface to support these new commands.

New Commands:

* [`Futurist.Repository.Command/MupCommand/MupSummaryByBatchNumberCommand.cs`](diffhunk://#diff-f1a61a931b6e9d60e684a4a407ef187aef174d477e7b961a2a2b56922e180414R1-R8): Added a new command class `MupSummaryByBatchNumberCommand` with a `ListRequest` property.
* [`Futurist.Repository.Command/MupCommand/MupSummaryByBatchNumberPagedListCommand.cs`](diffhunk://#diff-36537c615b9ecb5b9dfc42dd16cba68f425a345efd37bcb0b3dc6c1123bce652R1-R8): Added a new command class `MupSummaryByBatchNumberPagedListCommand` with a `PagedListRequest` property.
* [`Futurist.Repository.Command/MupCommand/MupSummaryByItemIdCommand.cs`](diffhunk://#diff-d0a5a8b9c0fd03e083383848643628a1e4f425a2a5c6d20b6b70a295e22da9a2R1-R8): Added a new command class `MupSummaryByItemIdCommand` with a `ListRequest` property.
* [`Futurist.Repository.Command/MupCommand/MupSummaryByItemIdPagedListCommand.cs`](diffhunk://#diff-046edfbaf20753e2238070396a6686f7f5b0a5628b13b494d59c3d81558bb0a3R1-R8): Added a new command class `MupSummaryByItemIdPagedListCommand` with a `PagedListRequest` property.

Modifications to Existing Commands:

* [`Futurist.Repository.Command/MupCommand/MupResultPagedListCommand.cs`](diffhunk://#diff-b446a3d77912983dbf7ab08ae06db1be08ef5aa0d04e51438177566ad755b9bbL1-R7): Removed the generic type parameter from the `PagedListRequest` property.

Updates to `IMupRepository` Interface:

* [`Futurist.Repository.Interface/IMupRepository.cs`](diffhunk://#diff-cff734ea94ea4781a9e8f7a7d198b0db895a6839daf59fc62f1bdd4aadf5b747L10-R16): Added new methods to handle the newly introduced commands for Mup summaries by item ID and batch number.