### PR TITLE
feat(FuturistHub): Add FgCostService dependency and implement GetFgCostInProcessRoomIds method

### DIFF
--- a/Futurist.Infrastructure.SignalR/Hubs/FuturistHub.cs
+++ b/Futurist.Infrastructure.SignalR/Hubs/FuturistHub.cs
@@ -9,11 +9,13 @@ public class FuturistHub : Hub
 {
     private readonly IMupService _mupService;
     private readonly IBomStdService _bomStdService;
+    private readonly IFgCostService _fgCostService;
 
-    public FuturistHub(IMupService mupService, IBomStdService bomStdService)
+    public FuturistHub(IMupService mupService, IBomStdService bomStdService, IFgCostService fgCostService)
     {
         _mupService = mupService;
         _bomStdService = bomStdService;
+        _fgCostService = fgCostService;
     }
     
     public Task<IEnumerable<int>> GetMupInProcessRoomIds()
@@ -24,5 +26,10 @@ public class FuturistHub : Hub
     public Task<IEnumerable<int>> GetBomStdInProcessRoomIds()
     {
         return Task.FromResult(_bomStdService.GetBomStdInProcessRoomIds());
+    }
+    
+    public Task<IEnumerable<int>> GetFgCostInProcessRoomIds()
+    {
+        return Task.FromResult(_fgCostService.GetFgCostInProcessRoomIds());
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `FuturistHub` class in the `Futurist.Infrastructure.SignalR/Hubs/FuturistHub.cs` file to incorporate a new service, `IFgCostService`. The most important changes include adding a new private readonly field for the service, updating the constructor to accept the new service, and adding a new method to use the service.

Integration of `IFgCostService`:

* [`Futurist.Infrastructure.SignalR/Hubs/FuturistHub.cs`](diffhunk://#diff-ecf2e8d4df8d684c1622378e2f80592c24ba5b9a201b9baab0073202564f6e5eR12-R18): Added a new private readonly field `_fgCostService` for the `IFgCostService` service.
* [`Futurist.Infrastructure.SignalR/Hubs/FuturistHub.cs`](diffhunk://#diff-ecf2e8d4df8d684c1622378e2f80592c24ba5b9a201b9baab0073202564f6e5eR12-R18): Updated the constructor of `FuturistHub` to accept an `IFgCostService` parameter and initialize the `_fgCostService` field.
* [`Futurist.Infrastructure.SignalR/Hubs/FuturistHub.cs`](diffhunk://#diff-ecf2e8d4df8d684c1622378e2f80592c24ba5b9a201b9baab0073202564f6e5eR30-R34): Added a new method `GetFgCostInProcessRoomIds` that uses `_fgCostService` to return the FG cost in-process room IDs.