### PR TITLE
feat(Rofo): Add GetRofoListCommand class to encapsulate room parameter for Rofo list retrieval

### DIFF
--- a/Futurist.Repository.Command/RofoCommand/GetRofoListCommand.cs
+++ b/Futurist.Repository.Command/RofoCommand/GetRofoListCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace Futurist.Repository.Command.RofoCommand;
+
+public class GetRofoListCommand : BaseCommand
+{
+    public int Room { get; set; }
+}


### PR DESCRIPTION
This pull request introduces a new command class `GetRofoListCommand` in the `Futurist.Repository.Command.RofoCommand` namespace to handle the retrieval of a list of Rofo items. 

Key changes:

* [`Futurist.Repository.Command/RofoCommand/GetRofoListCommand.cs`](diffhunk://#diff-5070341d5822a0ef34905cf8cd45c358df2038ebd3352babe3d100198bd6ea2cR1-R6): Added a new class `GetRofoListCommand` inheriting from `BaseCommand` with a property `Room` to specify the room number for the command.