### PR TITLE
feat(ServiceCollection): Register repositories for Job Monitoring, Exchange Rate, and Item Adjustment services

### DIFF
--- a/Futurist.Repository.SqlServer/ServiceCollectionExtensions.cs
+++ b/Futurist.Repository.SqlServer/ServiceCollectionExtensions.cs
@@ -17,6 +17,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICommonRepository, CommonRepository>();
         services.AddScoped<IMupRepository, MupRepository>();
         services.AddScoped<IFgCostRepository, FgCostRepository>();
+        services.AddScoped<IJobMonitoringRepository, JobMonitoringRepository>();
+        services.AddScoped<IExchangeRateRepository, ExchangeRateRepository>();
+        services.AddScoped<IItemAdjustmentRepository, ItemAdjustmentRepository>();
         
         services.AddScoped<IDbConnection>(s =>
         {


### PR DESCRIPTION
This pull request includes changes to the `AddRepositorySqlServer` method in the `Futurist.Repository.SqlServer/ServiceCollectionExtensions.cs` file. The changes involve registering additional repository interfaces with the dependency injection container.

Repository registrations added:

* `IJobMonitoringRepository`
* `IExchangeRateRepository`
* `IItemAdjustmentRepository`