### PR TITLE
feat(MapperlyMapper): Add mapping methods for Job Monitoring, Exchange Rate, SpTask, Item Adjustment, and FgCostVerSp entities

### DIFF
--- a/Futurist.Service/MapperlyMapper.cs
+++ b/Futurist.Service/MapperlyMapper.cs
@@ -2,6 +2,7 @@
 using Futurist.Domain.Common;
 using Futurist.Service.Dto;
 using Futurist.Service.Dto.Common;
+using Hangfire.Storage.Monitoring;
 using Riok.Mapperly.Abstractions;
 
 namespace Futurist.Service;
@@ -9,13 +10,17 @@ namespace Futurist.Service;
 [Mapper]
 public partial class MapperlyMapper
 {
+    // Common
+    public partial PagedListRequest MapToPagedListRequest(PagedListRequestDto dto);
+    public partial PagedListRequestDto MapToPagedListRequestDto(PagedListRequest entity);
+    public partial ListRequest MapToListRequest(ListRequestDto dto);
+    public partial ListRequestDto MapToListRequestDto(ListRequest entity);
+    
     // Rofo
     public partial Rofo MapToEntity(RofoDto dto);
     public partial RofoDto MapToDto(Rofo entity);
     public partial IEnumerable<Rofo> MapToIEnumerable(IEnumerable<RofoDto> dtos);
     public partial IEnumerable<RofoDto> MapToIEnumerableDto(IEnumerable<Rofo> entities);
-    public partial PagedListRequest<Rofo> MapToPagedListRequest(PagedListRequestDto<RofoDto> dto);
-    public partial PagedListRequestDto<RofoDto> MapToPagedListRequestDto(PagedListRequest<Rofo> entity);
     public partial PagedList<Rofo> MapToPagedList(PagedListDto<RofoDto> dto);
     public partial PagedListDto<RofoDto> MapToPagedListDto(PagedList<Rofo> entity);
     
@@ -24,8 +29,6 @@ public partial class MapperlyMapper
     public partial BomStdDto MapToDto(BomStd entity);
     public partial IEnumerable<BomStd> MapToIEnumerable(IEnumerable<BomStdDto> dtos);
     public partial IEnumerable<BomStdDto> MapToIEnumerableDto(IEnumerable<BomStd> entities);
-    public partial PagedListRequest<BomStd> MapToPagedListRequest(PagedListRequestDto<BomStdDto> dto);
-    public partial PagedListRequestDto<BomStdDto> MapToPagedListRequestDto(PagedListRequest<BomStd> entity);
     public partial PagedList<BomStd> MapToPagedList(PagedListDto<BomStdDto> dto);
     public partial PagedListDto<BomStdDto> MapToPagedListDto(PagedList<BomStd> entity);
     
@@ -34,8 +37,6 @@ public partial class MapperlyMapper
     public partial MupSpDto MapToDto(MupSp entity);
     public partial IEnumerable<MupSp> MapToIEnumerable(IEnumerable<MupSpDto> dtos);
     public partial IEnumerable<MupSpDto> MapToIEnumerableDto(IEnumerable<MupSp> entities);
-    public partial PagedListRequest<MupSp> MapToPagedListRequest(PagedListRequestDto<MupSpDto> dto);
-    public partial PagedListRequestDto<MupSpDto> MapToPagedListRequestDto(PagedListRequest<MupSp> entity);
     public partial PagedList<MupSp> MapToPagedList(PagedListDto<MupSpDto> dto);
     public partial PagedListDto<MupSpDto> MapToPagedListDto(PagedList<MupSp> entity);
     
@@ -44,8 +45,6 @@ public partial class MapperlyMapper
     public partial FgCostSpDto MapToDto(FgCostSp entity);
     public partial IEnumerable<FgCostSp> MapToIEnumerable(IEnumerable<FgCostSpDto> dtos);
     public partial IEnumerable<FgCostSpDto> MapToIEnumerableDto(IEnumerable<FgCostSp> entities);
-    public partial PagedListRequest<FgCostSp> MapToPagedListRequest(PagedListRequestDto<FgCostSpDto> dto);
-    public partial PagedListRequestDto<FgCostSpDto> MapToPagedListRequestDto(PagedListRequest<FgCostSp> entity);
     public partial PagedList<FgCostSp> MapToPagedList(PagedListDto<FgCostSpDto> dto);
     public partial PagedListDto<FgCostSpDto> MapToPagedListDto(PagedList<FgCostSp> entity);
     
@@ -54,8 +53,46 @@ public partial class MapperlyMapper
     public partial FgCostDetailSpDto MapToDto(FgCostDetailSp entity);
     public partial IEnumerable<FgCostDetailSp> MapToIEnumerable(IEnumerable<FgCostDetailSpDto> dtos);
     public partial IEnumerable<FgCostDetailSpDto> MapToIEnumerableDto(IEnumerable<FgCostDetailSp> entities);
-    public partial PagedListRequest<FgCostDetailSp> MapToPagedListRequest(PagedListRequestDto<FgCostDetailSpDto> dto);
-    public partial PagedListRequestDto<FgCostDetailSpDto> MapToPagedListRequestDto(PagedListRequest<FgCostDetailSp> entity);
     public partial PagedList<FgCostDetailSp> MapToPagedList(PagedListDto<FgCostDetailSpDto> dto);
     public partial PagedListDto<FgCostDetailSpDto> MapToPagedListDto(PagedList<FgCostDetailSp> entity);
+    
+    // Job Monitoring, ignore duration
+    public partial JobMonitoring MapToEntity(JobMonitoringDto dto);
+    public partial JobMonitoringDto MapToDto(JobMonitoring entity);
+    public partial IEnumerable<JobMonitoring> MapToIEnumerable(IEnumerable<JobMonitoringDto> dtos);
+    public partial IEnumerable<JobMonitoringDto> MapToIEnumerableDto(IEnumerable<JobMonitoring> entities);
+    public partial PagedList<JobMonitoring> MapToPagedList(PagedListDto<JobMonitoringDto> dto);
+    public partial PagedListDto<JobMonitoringDto> MapToPagedListDto(PagedList<JobMonitoring> entity);
+    
+    // Exchange Rate Sp
+    public partial ExchangeRateSp MapToEntity(ExchangeRateSpDto dto);
+    public partial ExchangeRateSpDto MapToDto(ExchangeRateSp entity);
+    public partial IEnumerable<ExchangeRateSp> MapToIEnumerable(IEnumerable<ExchangeRateSpDto> dtos);
+    public partial IEnumerable<ExchangeRateSpDto> MapToIEnumerableDto(IEnumerable<ExchangeRateSp> entities);
+    public partial PagedList<ExchangeRateSp> MapToPagedList(PagedListDto<ExchangeRateSpDto> dto);
+    public partial PagedListDto<ExchangeRateSpDto> MapToPagedListDto(PagedList<ExchangeRateSp> entity);
+    
+    // SpTask
+    public partial SpTask MapToEntity(SpTaskDto dto);
+    public partial SpTaskDto MapToDto(SpTask entity);
+    public partial IEnumerable<SpTask> MapToIEnumerable(IEnumerable<SpTaskDto> dtos);
+    public partial IEnumerable<SpTaskDto> MapToIEnumerableDto(IEnumerable<SpTask> entities);
+    public partial PagedList<SpTask> MapToPagedList(PagedListDto<SpTaskDto> dto);
+    public partial PagedListDto<SpTaskDto> MapToPagedListDto(PagedList<SpTask> entity);
+    
+    // Item Adjustment
+    public partial ItemAdjustment MapToEntity(ItemAdjustmentDto dto);
+    public partial ItemAdjustmentDto MapToDto(ItemAdjustment entity);
+    public partial IEnumerable<ItemAdjustment> MapToIEnumerable(IEnumerable<ItemAdjustmentDto> dtos);
+    public partial IEnumerable<ItemAdjustmentDto> MapToIEnumerableDto(IEnumerable<ItemAdjustment> entities);
+    public partial PagedList<ItemAdjustment> MapToPagedList(PagedListDto<ItemAdjustmentDto> dto);
+    public partial PagedListDto<ItemAdjustmentDto> MapToPagedListDto(PagedList<ItemAdjustment> entity);
+    
+    // FgCostVerSp
+    public partial FgCostVerSp MapToEntity(FgCostVerSpDto dto);
+    public partial FgCostVerSpDto MapToDto(FgCostVerSp entity);
+    public partial IEnumerable<FgCostVerSp> MapToIEnumerable(IEnumerable<FgCostVerSpDto> dtos);
+    public partial IEnumerable<FgCostVerSpDto> MapToIEnumerableDto(IEnumerable<FgCostVerSp> entities);
+    public partial PagedList<FgCostVerSp> MapToPagedList(PagedListDto<FgCostVerSpDto> dto);
+    public partial PagedListDto<FgCostVerSpDto> MapToPagedListDto(PagedList<FgCostVerSp> entity);
 }


### PR DESCRIPTION
This pull request includes changes to the `Futurist.Service/MapperlyMapper.cs` file, focusing on mapping methods for various DTOs and entities. The main changes involve adding new mapping methods for several entities and removing specific type mappings for `PagedListRequest` and `PagedListRequestDto`.

### Additions:
* Added mapping methods for `PagedListRequest` and `PagedListRequestDto` for common entities.
* Introduced mapping methods for `JobMonitoring` and `JobMonitoringDto`.
* Added mapping methods for `ExchangeRateSp` and `ExchangeRateSpDto`.
* Added mapping methods for `SpTask` and `SpTaskDto`.
* Introduced mapping methods for `ItemAdjustment` and `ItemAdjustmentDto`.
* Added mapping methods for `FgCostVerSp` and `FgCostVerSpDto`.

### Removals:
* Removed specific type mappings for `PagedListRequest` and `PagedListRequestDto` for `Rofo`, `BomStd`, `MupSp`, `FgCostSp`, and `FgCostDetailSp`. [[1]](diffhunk://#diff-c85eb60c56f01182b94acd4730d56571061bd82f06074b4d027c3183b6aa2b92L27-L28) [[2]](diffhunk://#diff-c85eb60c56f01182b94acd4730d56571061bd82f06074b4d027c3183b6aa2b92L37-L38) [[3]](diffhunk://#diff-c85eb60c56f01182b94acd4730d56571061bd82f06074b4d027c3183b6aa2b92L47-L48) [[4]](diffhunk://#diff-c85eb60c56f01182b94acd4730d56571061bd82f06074b4d027c3183b6aa2b92L57-R97)