### PR TITLE
feat(ServiceMessageConstants): Add new constants for Fg Cost Version status messages

### DIFF
--- a/Futurist.Service.Dto/Common/ServiceMessageConstants.cs
+++ b/Futurist.Service.Dto/Common/ServiceMessageConstants.cs
@@ -68,4 +68,10 @@ public static class ServiceMessageConstants
     public const string SummaryFgCostFound = "Summary Fg Cost found";
     public const string SummaryFgCostNotFound = "Summary Fg Cost not found";
     public const string RofoImportFailed = "Rofo import failed";
+    public const string FgCostVerFound = "Fg Cost Ver found";
+    public const string FgCostVerNotFound = "Fg Cost Ver not found";
+    public const string FgCostVerInserted = "Fg Cost Ver inserted";
+    public const string FgCostVerNotInserted = "Fg Cost Ver not inserted";
+    public const string FgCostVerRoomIdsFound = "Fg Cost Ver room IDs found";
+    public const string FgCostVerRoomIdsNotFound = "Fg Cost Ver room IDs not found";
 }


### PR DESCRIPTION
This pull request adds new constants to the `ServiceMessageConstants` class in the `Futurist.Service.Dto/Common/ServiceMessageConstants.cs` file. These constants are related to "Fg Cost Ver" operations, such as finding, inserting, and handling room IDs.

### Additions to `ServiceMessageConstants`:

* Added constants for "Fg Cost Ver" operations:
  - `FgCostVerFound`
  - `FgCostVerNotFound`
  - `FgCostVerInserted`
  - `FgCostVerNotInserted`
  - `FgCostVerRoomIdsFound`
  - `FgCostVerRoomIdsNotFound`