### PR TITLE
feat(Service.Interface): Add project reference to Futurist.Service.Command

### DIFF
--- a/Futurist.Service.Interface/Futurist.Service.Interface.csproj
+++ b/Futurist.Service.Interface/Futurist.Service.Interface.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Futurist.Service.Command\Futurist.Service.Command.csproj" />
       <ProjectReference Include="..\Futurist.Service.Dto\Futurist.Service.Dto.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
This pull request makes a small change to the `Futurist.Service.Interface.csproj` file by adding a project reference to the `Futurist.Service.Command` project. This ensures that the `Futurist.Service.Interface` project can access and use the `Futurist.Service.Command` project.