### PR TITLE
feat(FgCost): Enhance FgCost functionality with new properties and mappings for procurement and yield

### DIFF
--- a/Futurist.Domain/FgCostDetailSp.cs
+++ b/Futurist.Domain/FgCostDetailSp.cs
@@ -11,6 +11,7 @@ public class FgCostDetailSp
     public string ItemId { get; set; } = string.Empty;
     public string ItemName { get; set; } = string.Empty;
     public string GroupSubstitusi { get; set; } = string.Empty;
+    public string GroupProcurement { get; set; } = string.Empty;
     public string ItemAllocatedId { get; set; } = string.Empty;
     public string ItemAllocatedName { get; set; } = string.Empty;
     public string UnitId { get; set; } = string.Empty;

--- a/Futurist.Domain/FgCostSp.cs
+++ b/Futurist.Domain/FgCostSp.cs
@@ -13,6 +13,7 @@ public class FgCostSp
     public decimal Yield { get; set; }
     public decimal RmPrice { get; set; }
     public decimal PmPrice { get; set; }
+    public decimal RmPmYield { get; set; }
     public decimal StdCostPrice { get; set; }
     public decimal CostPrice { get; set; }
     public decimal SalesPriceIndex { get; set; }

--- a/Futurist.Service.Dto/FgCostDetailSpDto.cs
+++ b/Futurist.Service.Dto/FgCostDetailSpDto.cs
@@ -11,6 +11,7 @@ public class FgCostDetailSpDto
     public string ItemId { get; set; } = string.Empty;
     public string ItemName { get; set; } = string.Empty;
     public string GroupSubstitusi { get; set; } = string.Empty;
+    public string GroupProcurement { get; set; } = string.Empty;
     public string ItemAllocatedId { get; set; } = string.Empty;
     public string ItemAllocatedName { get; set; } = string.Empty;
     public string UnitId { get; set; } = string.Empty;

--- a/Futurist.Service.Dto/FgCostSpDto.cs
+++ b/Futurist.Service.Dto/FgCostSpDto.cs
@@ -13,6 +13,7 @@ public class FgCostSpDto
     public decimal Yield { get; set; }
     public decimal RmPrice { get; set; }
     public decimal PmPrice { get; set; }
+    public decimal RmPmYield { get; set; }
     public decimal StdCostPrice { get; set; }
     public decimal CostPrice { get; set; }
     public decimal SalesPriceIndex { get; set; }

--- a/Futurist.Web/Controllers/FgCostController.cs
+++ b/Futurist.Web/Controllers/FgCostController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Futurist.Web.Controllers;
 
+[Authorize]
 public class FgCostController : Controller
 {
     private readonly IFgCostService _fgCostService;
@@ -91,9 +92,10 @@ public class FgCostController : Controller
                 row.Cell(9).Value = "Yield";
                 row.Cell(10).Value = "RM Price";
                 row.Cell(11).Value = "PM Price";
-                row.Cell(12).Value = "Std Cost Price";
-                row.Cell(13).Value = "Cost Price";
-                row.Cell(14).Value = "Sales Price Index";
+                row.Cell(12).Value = "RMPM+Y";
+                row.Cell(13).Value = "Std Cost Price";
+                row.Cell(14).Value = "Cost Price";
+                row.Cell(15).Value = "Sales Price Index";
             }
             else
             {
@@ -113,13 +115,14 @@ public class FgCostController : Controller
                 row.Cell(10).Style.NumberFormat.Format = "#,##0";
                 row.Cell(11).Value = dto.PmPrice;
                 row.Cell(11).Style.NumberFormat.Format = "#,##0";
-                row.Cell(12).Value = dto.StdCostPrice;
+                row.Cell(12).Value = dto.RmPmYield;
                 row.Cell(12).Style.NumberFormat.Format = "#,##0";
-                row.Cell(13).Value = dto.CostPrice;
+                row.Cell(13).Value = dto.StdCostPrice;
                 row.Cell(13).Style.NumberFormat.Format = "#,##0";
-                row.Cell(14).Value = dto.SalesPriceIndex;
+                row.Cell(14).Value = dto.CostPrice;
                 row.Cell(14).Style.NumberFormat.Format = "#,##0";
-                row.Cell(14).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Right;
+                row.Cell(15).Value = dto.SalesPriceIndex;
+                row.Cell(15).Style.NumberFormat.Format = "#,##0";
             }
         });
         
@@ -137,6 +140,7 @@ public class FgCostController : Controller
         {
             if (row.RowNumber() == 1)
             {
+                // New header with UnitId added after Product Name
                 row.Cell(1).Value = "Room";
                 row.Cell(2).Value = "Rofo ID";
                 row.Cell(3).Value = "Product ID";
@@ -146,17 +150,19 @@ public class FgCostController : Controller
                 row.Cell(7).Value = "Item ID";
                 row.Cell(8).Value = "Item Name";
                 row.Cell(9).Value = "Group Substitusi";
-                row.Cell(10).Value = "Item Allocated ID";
-                row.Cell(11).Value = "Item Allocated Name";
-                row.Cell(12).Value = "Batch";
-                row.Cell(13).Value = "Qty";
-                row.Cell(14).Value = "Price";
-                row.Cell(15).Value = "RM Price";
-                row.Cell(16).Value = "PM Price";
-                row.Cell(17).Value = "Std Cost Price";
-                row.Cell(18).Value = "Source";
-                row.Cell(19).Value = "Ref ID";
-                row.Cell(20).Value = "Latest Purchase Price";
+                row.Cell(10).Value = "Group Procurement";
+                row.Cell(11).Value = "Item Allocated ID";
+                row.Cell(12).Value = "Item Allocated Name";
+                row.Cell(13).Value = "Unit";
+                row.Cell(14).Value = "Batch";
+                row.Cell(15).Value = "Qty";
+                row.Cell(16).Value = "Price";
+                row.Cell(17).Value = "RM Price";
+                row.Cell(18).Value = "PM Price";
+                row.Cell(19).Value = "Std Cost Price";
+                row.Cell(20).Value = "Source";
+                row.Cell(21).Value = "Ref ID";
+                row.Cell(22).Value = "Latest Purchase Price";
             }
             else
             {
@@ -167,24 +173,32 @@ public class FgCostController : Controller
                 row.Cell(5).Value = dto.RofoDate;
                 row.Cell(5).Style.NumberFormat.Format = "dd MMM yyyy";
                 row.Cell(6).Value = dto.RofoQty;
+                row.Cell(6).Style.NumberFormat.Format = "#,##0";
                 row.Cell(7).Value = dto.ItemId;
                 row.Cell(8).Value = dto.ItemName;
                 row.Cell(9).Value = dto.GroupSubstitusi;
-                row.Cell(10).Value = dto.ItemAllocatedId;
-                row.Cell(11).Value = dto.ItemAllocatedName;
-                row.Cell(12).Value = dto.InventBatch;
-                row.Cell(13).Value = dto.Qty;
-                row.Cell(14).Value = dto.Price;
-                row.Cell(15).Value = dto.RmPrice;
-                row.Cell(16).Value = dto.PmPrice;
-                row.Cell(17).Value = dto.StdCostPrice;
-                row.Cell(18).Value = dto.Source;
-                row.Cell(19).Value = dto.RefId;
-                row.Cell(20).Value = dto.LatestPurchasePrice;
+                row.Cell(10).Value = dto.GroupProcurement;
+                row.Cell(11).Value = dto.ItemAllocatedId;
+                row.Cell(12).Value = dto.ItemAllocatedName;
+                row.Cell(13).Value = dto.UnitId;
+                row.Cell(14).Value = dto.InventBatch;
+                row.Cell(15).Value = dto.Qty;
+                row.Cell(15).Style.NumberFormat.Format = "#,##0.00";
+                row.Cell(16).Value = dto.Price;
+                row.Cell(16).Style.NumberFormat.Format = "#,##0";
+                row.Cell(17).Value = dto.RmPrice;
+                row.Cell(17).Style.NumberFormat.Format = "#,##0";
+                row.Cell(18).Value = dto.PmPrice;
+                row.Cell(18).Style.NumberFormat.Format = "#,##0";
+                row.Cell(19).Value = dto.StdCostPrice;
+                row.Cell(19).Style.NumberFormat.Format = "#,##0";
+                row.Cell(20).Value = dto.Source;
+                row.Cell(21).Value = dto.RefId;
+                row.Cell(22).Value = dto.LatestPurchasePrice;
+                row.Cell(22).Style.NumberFormat.Format = "#,##0";
             }
         });
 
-        // download as excel file
         return File(result, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             $"FgCostDetail_{DateTime.Now:yyyyMMddHHmmss}.xlsx");
     }
@@ -199,26 +213,29 @@ public class FgCostController : Controller
         {
             if (row.RowNumber() == 1)
             {
+                // New header with UnitId added
                 row.Cell(1).Value = "Room";
                 row.Cell(2).Value = "Rofo ID";
                 row.Cell(3).Value = "Product ID";
                 row.Cell(4).Value = "Product Name";
-                row.Cell(5).Value = "Rofo Date";
-                row.Cell(6).Value = "Rofo Qty";
-                row.Cell(7).Value = "Item ID";
-                row.Cell(8).Value = "Item Name";
-                row.Cell(9).Value = "Group Substitusi";
-                row.Cell(10).Value = "Item Allocated ID";
-                row.Cell(11).Value = "Item Allocated Name";
-                row.Cell(12).Value = "Batch";
-                row.Cell(13).Value = "Qty";
-                row.Cell(14).Value = "Price";
-                row.Cell(15).Value = "RM Price";
-                row.Cell(16).Value = "PM Price";
-                row.Cell(17).Value = "Std Cost Price";
-                row.Cell(18).Value = "Source";
-                row.Cell(19).Value = "Ref ID";
-                row.Cell(20).Value = "Latest Purchase Price";
+                row.Cell(5).Value = "UnitId";   // new header
+                row.Cell(6).Value = "Rofo Date";
+                row.Cell(7).Value = "Rofo Qty";
+                row.Cell(8).Value = "Item ID";
+                row.Cell(9).Value = "Item Name";
+                row.Cell(10).Value = "Group Substitusi";
+                row.Cell(11).Value = "Group Procurement";
+                row.Cell(12).Value = "Item Allocated ID";
+                row.Cell(13).Value = "Item Allocated Name";
+                row.Cell(14).Value = "Batch";
+                row.Cell(15).Value = "Qty";
+                row.Cell(16).Value = "Price";
+                row.Cell(17).Value = "RM Price";
+                row.Cell(18).Value = "PM Price";
+                row.Cell(19).Value = "Std Cost Price";
+                row.Cell(20).Value = "Source";
+                row.Cell(21).Value = "Ref ID";
+                row.Cell(22).Value = "Latest Purchase Price";
             }
             else
             {
@@ -226,29 +243,32 @@ public class FgCostController : Controller
                 row.Cell(2).Value = dto.RofoId;
                 row.Cell(3).Value = dto.ProductId;
                 row.Cell(4).Value = dto.ProductName;
-                row.Cell(5).Value = dto.RofoDate;
-                row.Cell(5).Style.NumberFormat.Format = "dd MMM yyyy";
-                row.Cell(6).Value = dto.RofoQty;
-                row.Cell(7).Value = dto.ItemId;
-                row.Cell(8).Value = dto.ItemName;
-                row.Cell(9).Value = dto.GroupSubstitusi;
-                row.Cell(10).Value = dto.ItemAllocatedId;
-                row.Cell(11).Value = dto.ItemAllocatedName;
-                row.Cell(12).Value = dto.InventBatch;
-                row.Cell(13).Value = dto.Qty;
-                row.Cell(13).Style.NumberFormat.Format = "#,##0.00";
-                row.Cell(14).Value = dto.Price;
-                row.Cell(14).Style.NumberFormat.Format = "#,##0";
-                row.Cell(15).Value = dto.RmPrice;
-                row.Cell(15).Style.NumberFormat.Format = "#,##0";
-                row.Cell(16).Value = dto.PmPrice;
+                row.Cell(5).Value = dto.UnitId;  // new value
+                row.Cell(6).Value = dto.RofoDate;
+                row.Cell(6).Style.NumberFormat.Format = "dd MMM yyyy";
+                row.Cell(7).Value = dto.RofoQty;
+                row.Cell(7).Style.NumberFormat.Format = "#,##0";
+                row.Cell(8).Value = dto.ItemId;
+                row.Cell(9).Value = dto.ItemName;
+                row.Cell(10).Value = dto.GroupSubstitusi;
+                row.Cell(11).Value = dto.GroupProcurement;
+                row.Cell(12).Value = dto.ItemAllocatedId;
+                row.Cell(13).Value = dto.ItemAllocatedName;
+                row.Cell(14).Value = dto.InventBatch;
+                row.Cell(15).Value = dto.Qty;
+                row.Cell(15).Style.NumberFormat.Format = "#,##0.00";
+                row.Cell(16).Value = dto.Price;
                 row.Cell(16).Style.NumberFormat.Format = "#,##0";
-                row.Cell(17).Value = dto.StdCostPrice;
+                row.Cell(17).Value = dto.RmPrice;
                 row.Cell(17).Style.NumberFormat.Format = "#,##0";
-                row.Cell(18).Value = dto.Source;
-                row.Cell(19).Value = dto.RefId;
-                row.Cell(20).Value = dto.LatestPurchasePrice;
-                row.Cell(20).Style.NumberFormat.Format = "#,##0";
+                row.Cell(18).Value = dto.PmPrice;
+                row.Cell(18).Style.NumberFormat.Format = "#,##0";
+                row.Cell(19).Value = dto.StdCostPrice;
+                row.Cell(19).Style.NumberFormat.Format = "#,##0";
+                row.Cell(20).Value = dto.Source;
+                row.Cell(21).Value = dto.RefId;
+                row.Cell(22).Value = dto.LatestPurchasePrice;
+                row.Cell(22).Style.NumberFormat.Format = "#,##0";
             }
         });
         

--- a/Futurist.Web/Views/FgCost/Details.cshtml
+++ b/Futurist.Web/Views/FgCost/Details.cshtml
@@ -35,7 +35,7 @@
                     </button>
                     <a asp-controller="FgCost" asp-action="DownloadFgCostDetail" asp-route-room="0" onclick="downloadFgCostDetail()" id="linkDownload" class="btn btn-info">
                         <i class="ri-file-excel-2-fill"></i>
-                        Export Result
+                        Download Result
                     </a>
                 </div>
             </div>
@@ -52,8 +52,10 @@
                         <th>Item ID</th>
                         <th>Item Name</th>
                         <th>Group Substitusi</th>
+                        <th>Group Procurement</th>
                         <th>Item Allocated ID</th>
                         <th>Item Allocated Name</th>
+                        <th>Unit</th>
                         <th>Batch</th>
                         <th>Qty</th>
                         <th>Price</th>
@@ -76,8 +78,10 @@
                         <th>Item ID</th>
                         <th>Item Name</th>
                         <th>Group Substitusi</th>
+                        <th>Group Procurement</th>
                         <th>Item Allocated ID</th>
                         <th>Item Allocated Name</th>
+                        <th>Unit</th>
                         <th>Batch</th>
                         <th>Qty</th>
                         <th>Price</th>
@@ -116,7 +120,7 @@
         }
 
         function reloadTable() {
-            if (document.getElementById("datatables-fgcost-result") || document.getElementById("datatables-fgcost-result")) {
+            if (document.getElementById("datatables-fgcost-result")) {
                 if (!initialized) {
                     initialized = true;
                     $('#datatables-fgcost-result').DataTable({
@@ -174,14 +178,16 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             { data: 'itemId', defaultContent: '' },
                             { data: 'itemName', width: '200px', defaultContent: '' },
                             { data: 'groupSubstitusi', defaultContent: '' },
+                            { data: 'groupProcurement', defaultContent: '' },
                             { data: 'itemAllocatedId', defaultContent: '' },
                             { data: 'itemAllocatedName', width: '200px', defaultContent: '' },
+                            { data: 'unitId', defaultContent: '' },
                             { data: 'inventBatch', defaultContent: '' },
                             {
                                 data: 'qty',
@@ -193,7 +199,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -206,7 +212,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -219,7 +225,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -232,7 +238,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -245,7 +251,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             { data: 'source', defaultContent: '' },
@@ -260,13 +266,13 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                         ],
                         columnDefs: [
                             {
-                                targets: [0, 1, 2, 4, 6, 8, 9, 11, 15, 16], // Column indices to center
+                                targets: [0, 1, 2, 4, 6, 8, 9, 10, 12, 16, 17], // Column indices to center
                                 className: 'text-center'
                             }
                         ],

--- a/Futurist.Web/Views/FgCost/DetailsByRofoId.cshtml
+++ b/Futurist.Web/Views/FgCost/DetailsByRofoId.cshtml
@@ -28,7 +28,7 @@
                     </a>
                     <a asp-controller="FgCost" asp-action="DownloadFgCostDetailsByRofoId" asp-route-rofoId="0" onclick="downloadFgCostDetailByRofoId()" id="linkDownload" class="btn btn-info">
                         <i class="ri-file-excel-2-fill"></i>
-                        Export Result
+                        Download Result
                     </a>
                 </div>
             </div>
@@ -47,7 +47,7 @@
                         <th>Group Substitusi</th>
                         <th>Item Allocated ID</th>
                         <th>Item Allocated Name</th>
-                        <th>Unit ID</th>
+                        <th>Unit</th>
                         <th>Batch</th>
                         <th>Qty</th>
                         <th>Price</th>
@@ -72,7 +72,7 @@
                         <th>Group Substitusi</th>
                         <th>Item Allocated ID</th>
                         <th>Item Allocated Name</th>
-                        <th>Unit ID</th>
+                        <th>Unit</th>
                         <th>Batch</th>
                         <th>Qty</th>
                         <th>Price</th>
@@ -168,7 +168,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { data: 'itemId', defaultContent: '' },
@@ -188,7 +188,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { 
@@ -201,7 +201,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { 
@@ -214,7 +214,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { 
@@ -227,7 +227,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { 
@@ -240,7 +240,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { data: 'source', defaultContent: '' },
@@ -255,7 +255,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                 ],

--- a/Futurist.Web/Views/FgCost/Index.cshtml
+++ b/Futurist.Web/Views/FgCost/Index.cshtml
@@ -35,7 +35,7 @@
                     </button>
                     <a asp-controller="FgCost" asp-action="DownloadSummaryFgCost" asp-route-room="0" onclick="downloadSummaryFgCost()" id="linkDownload" class="btn btn-info">
                         <i class="ri-file-excel-2-fill"></i>
-                        Export Result
+                        Download Result
                     </a>
                 </div>
             </div>
@@ -54,6 +54,7 @@
                         <th>Yield</th>
                         <th>RM Price</th>
                         <th>PM Price</th>
+                        <th>RMPM+Y</th>
                         <th>Std Cost Price</th>
                         <th>Cost Price</th>
                         <th>Sales Price Index</th>
@@ -72,6 +73,7 @@
                         <th>Yield</th>
                         <th>RM Price</th>
                         <th>PM Price</th>
+                        <th>RMPM+Y</th>
                         <th>Std Cost Price</th>
                         <th>Cost Price</th>
                         <th>Sales Price Index</th>
@@ -163,7 +165,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -188,7 +190,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -201,7 +203,20 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
+                                }
+                            },
+                            {
+                                data: 'rmPmYield',
+                                defaultContent: '',
+                                render: function(data, type) {
+                                    // For sorting/filtering use the raw number
+                                    if (type === 'sort' || type === 'filter') {
+                                        return data ? parseFloat(data) : 0;
+                                    }
+
+                                    // For display, round and format with thousands separator
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -214,7 +229,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -227,7 +242,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -240,7 +255,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             }
                         ],


### PR DESCRIPTION
This pull request introduces several updates across the domain, service, repository, and web layers to enhance functionality and improve data handling. Key changes include the addition of new fields (`GroupProcurement` and `RmPmYield`), updates to repository mappings, adjustments to service logic to use a unit-of-work pattern, and modifications to the web layer for improved data representation and export functionality.

### Domain and DTO Updates:
* Added `GroupProcurement` to `FgCostDetailSp` and `FgCostDetailSpDto` classes to include procurement group information. (`[[1]](diffhunk://#diff-b63c2d22e296ee357a0eda861cce3f3661caeadc9a8ab7f66e48f19c349c1dbdR14)`, `[[2]](diffhunk://#diff-7c478da51a041ee6d79aabd9423e4482c0a7c789c5f29601dc636a18fefdf18eR14)`)
* Added `RmPmYield` to `FgCostSp` and `FgCostSpDto` classes to capture combined yield data. (`[[1]](diffhunk://#diff-550dc218917b85062368e5487d41f8f248166b8c542b5c5b80ca11344f5d0e1dR16)`, `[[2]](diffhunk://#diff-6615f3ea37d2f2d924df943ddd380188922a3644cd66598e5a5198aaa13a7d9dR16)`)

### Repository Enhancements:
* Implemented custom column mappings in `FgCostRepository` to handle database column name differences (e.g., mapping "RmPm+Y" to `RmPmYield`). (`[Futurist.Repository.SqlServer/FgCostRepository.csR32-R44](diffhunk://#diff-101557d958a89fec53266aa89a7a91d2da8914653da75823880966e6fa7aed12R32-R44)`)

### Service Layer Refactoring:
* Replaced direct repository usage with a unit-of-work pattern in `FgCostVerService`, improving transaction management with explicit commit and rollback calls. (`[[1]](diffhunk://#diff-2445efbbdcb0d1210786075c0c3783d98cd80b3f90818ad165fa90b6e5e9c5cfL11-R17)`, `[[2]](diffhunk://#diff-2445efbbdcb0d1210786075c0c3783d98cd80b3f90818ad165fa90b6e5e9c5cfL55-R57)`, `[[3]](diffhunk://#diff-2445efbbdcb0d1210786075c0c3783d98cd80b3f90818ad165fa90b6e5e9c5cfR67-R68)`)

### Web Layer Updates:
* Added `[Authorize]` attribute to `FgCostController` for access control. (`[Futurist.Web/Controllers/FgCostController.csR10](diffhunk://#diff-6f95cd71c341de7c4b224b04c25c97478ff3447d710272b9809eba2d484317ccR10)`)
* Updated Excel export headers and data mappings in `DownloadSummaryFgCost` and `DownloadFgCostDetail` methods to include new fields (`GroupProcurement`, `RmPmYield`, and `UnitId`). (`[[1]](diffhunk://#diff-6f95cd71c341de7c4b224b04c25c97478ff3447d710272b9809eba2d484317ccL94-R98)`, `[[2]](diffhunk://#diff-6f95cd71c341de7c4b224b04c25c97478ff3447d710272b9809eba2d484317ccL149-R165)`, `[[3]](diffhunk://#diff-6f95cd71c341de7c4b224b04c25c97478ff3447d710272b9809eba2d484317ccR216-R271)`)
* Changed button text from "Export Result" to "Download Result" in the `Details.cshtml` view for clarity. (`[Futurist.Web/Views/FgCost/Details.cshtmlL38-R38](diffhunk://#diff-0b33e1900bef3f2394ae1eb75e9d9410cd5120b92df5f3fdfc50e4b12a8980f5L38-R38)`)