### PR TITLE
feat(ExcelHelper): Simplify CreateExcelTemplate method signature by removing generic type parameter

### DIFF
--- a/Futurist.Common/Helpers/ExcelHelper.cs
+++ b/Futurist.Common/Helpers/ExcelHelper.cs
@@ -67,7 +67,7 @@ public static class ExcelHelper
         return stream;
     }
 
-    public static Stream CreateExcelTemplate<T>(Action<List<string>> mapHeader)
+    public static Stream CreateExcelTemplate(Action<List<string>> mapHeader)
     {
         using var workbook = new XLWorkbook();
         var worksheet = workbook.Worksheets.Add("Sheet1");


### PR DESCRIPTION
This pull request includes a minor change to the `CreateExcelTemplate` method in `ExcelHelper.cs`. The change removes the generic type parameter `<T>` from the method signature, as it was not being used.