### PR TITLE
feat(ItemForecast): Implement item forecast functionality with repository, service, and controller layers

### DIFF
--- a/Futurist.Domain/ItemForecastSp.cs
+++ b/Futurist.Domain/ItemForecastSp.cs
@@ -1,0 +1,18 @@
+﻿using System.Data.SqlTypes;
+
+namespace Futurist.Domain;
+
+public class ItemForecastSp
+{
+    public int Room { get; set; }
+    public string ItemId { get; set; } = string.Empty;
+    public string ItemName { get; set; } = string.Empty;
+    public string UnitId { get; set; } = string.Empty;
+    public string VtaMpSubstitusiGroupId { get; set; } = string.Empty;
+    public string GroupProcurement { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public DateTime LatestPurchaseDate { get; set; } = SqlDateTime.MinValue.Value;
+    public DateTime ForecastDate { get; set; } = SqlDateTime.MinValue.Value;
+    public decimal ForecastPrice { get; set; }
+    public decimal? ForcedPrice { get; set; }
+}

--- a/Futurist.Repository.Command/ItemForecast/GetItemForecastListCommand.cs
+++ b/Futurist.Repository.Command/ItemForecast/GetItemForecastListCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace Futurist.Repository.Command.ItemForecast;
+
+public class GetItemForecastListCommand : BaseCommand
+{
+    public int Room { get; set; }
+}

--- a/Futurist.Repository.Command/ItemForecast/GetItemForecastRoomIdsCommand.cs
+++ b/Futurist.Repository.Command/ItemForecast/GetItemForecastRoomIdsCommand.cs
@@ -1,0 +1,3 @@
+﻿namespace Futurist.Repository.Command.ItemForecast;
+
+public class GetItemForecastRoomIdsCommand : BaseCommand;

--- a/Futurist.Repository.Command/ItemForecast/InsertItemForecastCommand.cs
+++ b/Futurist.Repository.Command/ItemForecast/InsertItemForecastCommand.cs
@@ -1,0 +1,14 @@
+﻿namespace Futurist.Repository.Command.ItemForecast;
+
+public class InsertItemForecastCommand : BaseCommand
+{
+    // @Room int=5
+    // ,@ItemId nvarchar(20) = '1000007'
+    // ,@ForecastDate datetime = '1-Apr-2025'
+    // ,@ForcedPrice numeric(32,16) =  12130
+    
+    public int Room { get; set; }
+    public string ItemId { get; set; } = string.Empty;
+    public DateTime ForecastDate { get; set; } = new DateTime(2025, 4, 1);
+    public decimal? ForcedPrice { get; set; }
+}

--- a/Futurist.Repository.Interface/IItemForecastRepository.cs
+++ b/Futurist.Repository.Interface/IItemForecastRepository.cs
@@ -1,0 +1,11 @@
+﻿using Futurist.Domain;
+using Futurist.Repository.Command.ItemForecast;
+
+namespace Futurist.Repository.Interface;
+
+public interface IItemForecastRepository
+{
+    Task<IEnumerable<ItemForecastSp>> GetItemForecastListAsync(GetItemForecastListCommand command);
+    Task InsertItemForecastAsync(InsertItemForecastCommand command);
+    Task<IEnumerable<int>> GetItemForecastRoomIdsAsync(GetItemForecastRoomIdsCommand command);
+}

--- a/Futurist.Repository.SqlServer/ItemForecastRepository.cs
+++ b/Futurist.Repository.SqlServer/ItemForecastRepository.cs
@@ -1,0 +1,85 @@
+﻿using System.Data;
+using System.Data.SqlTypes;
+using Dapper;
+using Futurist.Domain;
+using Futurist.Repository.Command.ItemForecast;
+using Futurist.Repository.Interface;
+
+namespace Futurist.Repository.SqlServer;
+
+public class ItemForecastRepository : IItemForecastRepository
+{
+    private readonly IDbConnection _sqlConnection;
+
+    public ItemForecastRepository(IDbConnection sqlConnection)
+    {
+        _sqlConnection = sqlConnection;
+    }
+
+    public async Task<IEnumerable<ItemForecastSp>> GetItemForecastListAsync(GetItemForecastListCommand command)
+    {
+        const string query = "ItemForecastRoom_UploadSelect";
+        var parameters = new DynamicParameters();
+        parameters.Add("@Room", command.Room);
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        return await _sqlConnection.QueryAsync<ItemForecastSp>(
+            query,
+            parameters,
+            command.DbTransaction,
+            commandType: CommandType.StoredProcedure);
+    }
+
+    public async Task InsertItemForecastAsync(InsertItemForecastCommand command)
+    {
+        const string query = "ItemForecastRoom_Upload";
+        var parameters = new DynamicParameters();
+        
+        if (command.Room > 0)
+        {
+            parameters.Add("@Room", command.Room);
+        }
+        
+        if (command.ItemId != string.Empty)
+        {
+            parameters.Add("@ItemId", command.ItemId);
+        }
+        
+        if (command.ForecastDate != SqlDateTime.MinValue.Value)
+        {
+            parameters.Add("@ForecastDate", command.ForecastDate);
+        }
+
+        if (command.ForcedPrice != 0)
+        {
+            parameters.Add("@ForcedPrice", command.ForcedPrice);
+        }
+        
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        await _sqlConnection.ExecuteAsync(
+            query,
+            parameters,
+            command.DbTransaction,
+            commandType: CommandType.StoredProcedure);
+    }
+
+    public async Task<IEnumerable<int>> GetItemForecastRoomIdsAsync(GetItemForecastRoomIdsCommand command)
+    {
+        const string query = """
+                             SELECT DISTINCT Room FROM ItemForecastRoom
+                             UNION
+                             SELECT DISTINCT Room FROM FgCost
+                             UNION
+                             SELECT DISTINCT Room FROM Mup
+                             UNION
+                             SELECT DISTINCT Room FROM BomStd
+                             UNION
+                             SELECT DISTINCT Room FROM Rofo
+                             UNION
+                             SELECT DISTINCT Room FROM ItemAdj
+                             ORDER BY Room;
+                             """;
+        
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        return await _sqlConnection.QueryAsync<int>(query, transaction: command.DbTransaction);
+    }
+}

--- a/Futurist.Repository.UnitOfWork/IUnitOfWork.cs
+++ b/Futurist.Repository.UnitOfWork/IUnitOfWork.cs
@@ -14,6 +14,7 @@ public interface IUnitOfWork : IDisposable, IAsyncDisposable
     IExchangeRateRepository ExchangeRateRepository { get; }
     IItemAdjustmentRepository ItemAdjustmentRepository { get; }
     IFgCostVerRepository FgCostVerRepository { get; }
+    IItemForecastRepository ItemForecastRepository { get; }
     IDbTransaction? CurrentTransaction { get; }
     IDbTransaction BeginTransaction();
     Task CommitAsync();

--- a/Futurist.Repository.UnitOfWork/UnitOfWork.cs
+++ b/Futurist.Repository.UnitOfWork/UnitOfWork.cs
@@ -20,6 +20,7 @@ public class UnitOfWork : IUnitOfWork
         IExchangeRateRepository exchangeRateRepository,
         IItemAdjustmentRepository itemAdjustmentRepository,
         IFgCostVerRepository fgCostVerRepository,
+        IItemForecastRepository itemForecastRepository,
         Func<IDbTransaction> transactionFactory)
     {
         _dbConnection = dbConnection;
@@ -33,6 +34,8 @@ public class UnitOfWork : IUnitOfWork
         ExchangeRateRepository = exchangeRateRepository;
         JobMonitoringRepository = jobMonitoringRepository;
         FgCostRepository = fgCostRepository;
+        ItemForecastRepository = itemForecastRepository;
+        
     }
     
     public IDbTransaction? CurrentTransaction { get; private set; }
@@ -52,6 +55,7 @@ public class UnitOfWork : IUnitOfWork
     public IExchangeRateRepository ExchangeRateRepository { get; }
     public IItemAdjustmentRepository ItemAdjustmentRepository { get; }
     public IFgCostVerRepository FgCostVerRepository { get; }
+    public IItemForecastRepository ItemForecastRepository { get; }
 
     public async Task CommitAsync()
     {

--- a/Futurist.Service.Command/ItemForecastCommand/ImportCommand.cs
+++ b/Futurist.Service.Command/ItemForecastCommand/ImportCommand.cs
@@ -1,0 +1,7 @@
+﻿namespace Futurist.Service.Command.ItemForecastCommand;
+
+public class ImportCommand
+{
+    public Stream Stream { get; set; }
+    public string User { get; set; } = string.Empty;
+}

--- a/Futurist.Service.Dto/Common/ServiceMessageConstants.cs
+++ b/Futurist.Service.Dto/Common/ServiceMessageConstants.cs
@@ -74,4 +74,13 @@ public static class ServiceMessageConstants
     public const string FgCostVerNotInserted = "Fg Cost Ver not inserted";
     public const string FgCostVerRoomIdsFound = "Fg Cost Ver room IDs found";
     public const string FgCostVerRoomIdsNotFound = "Fg Cost Ver room IDs not found";
+    public const string ItemForecastNotFound = "Item Forecast not found";
+    public const string ItemForecastItemIdInvalid = "Item Forecast item ID invalid";
+    public const string ItemForecastForecastDateInvalid = "Item Forecast forecast date invalid";
+    public const string ItemForecastForcedPriceInvalid = "Item Forecast forced price invalid";
+    public const string ItemForecastImportValidationFailed = "Item Forecast import validation failed";
+    public const string ItemForecastImportSuccess = "Item Forecast import success";
+    public const string ItemForecastImportFailed = "Item Forecast import failed";
+    public const string ItemForecastRoomIdsFound = "Item Forecast room IDs found";
+    public const string ItemForecastRoomIdsNotFound = "Item Forecast room IDs not found";
 }

--- a/Futurist.Service.Dto/ItemForecastSpDto.cs
+++ b/Futurist.Service.Dto/ItemForecastSpDto.cs
@@ -1,0 +1,18 @@
+﻿using System.Data.SqlTypes;
+
+namespace Futurist.Service.Dto;
+
+public class ItemForecastSpDto
+{
+    public int Room { get; set; }
+    public string ItemId { get; set; } = string.Empty;
+    public string ItemName { get; set; } = string.Empty;
+    public string UnitId { get; set; } = string.Empty;
+    public string VtaMpSubstitusiGroupId { get; set; } = string.Empty;
+    public string GroupProcurement { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public DateTime LatestPurchaseDate { get; set; } = SqlDateTime.MinValue.Value;
+    public DateTime ForecastDate { get; set; } = SqlDateTime.MinValue.Value;
+    public decimal ForecastPrice { get; set; }
+    public decimal? ForcedPrice { get; set; }
+}

--- a/Futurist.Service.Interface/IItemForecastService.cs
+++ b/Futurist.Service.Interface/IItemForecastService.cs
@@ -1,0 +1,12 @@
+﻿using Futurist.Service.Command.ItemForecastCommand;
+using Futurist.Service.Dto;
+using Futurist.Service.Dto.Common;
+
+namespace Futurist.Service.Interface;
+
+public interface IItemForecastService
+{
+    Task<ServiceResponse<IEnumerable<ItemForecastSpDto>>> GetItemForecastListAsync(int room);
+    Task<ServiceResponse> ImportAsync(ImportCommand serviceCommand);
+    Task<ServiceResponse<IEnumerable<int>>> GetItemForecastRoomIdsAsync();
+}

--- a/Futurist.Service/ItemForecastService.cs
+++ b/Futurist.Service/ItemForecastService.cs
@@ -1,0 +1,155 @@
+﻿using System.Data.SqlTypes;
+using Futurist.Common.Helpers;
+using Futurist.Repository.Command.ItemForecast;
+using Futurist.Repository.UnitOfWork;
+using Futurist.Service.Command.ItemForecastCommand;
+using Futurist.Service.Dto;
+using Futurist.Service.Dto.Common;
+using Futurist.Service.Interface;
+using Serilog;
+
+namespace Futurist.Service;
+
+public class ItemForecastService : IItemForecastService
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MapperlyMapper _mapper;
+    private readonly ILogger _logger = Log.ForContext<ItemForecastService>();
+
+    public ItemForecastService(IUnitOfWork unitOfWork, MapperlyMapper mapper)
+    {
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<ServiceResponse<IEnumerable<ItemForecastSpDto>>> GetItemForecastListAsync(int room)
+    {
+        try
+        {
+            var command = new GetItemForecastListCommand
+            {
+                Room = room
+            };
+
+            var result = await _unitOfWork.ItemForecastRepository.GetItemForecastListAsync(command);
+
+            return new ServiceResponse<IEnumerable<ItemForecastSpDto>>
+            {
+                Data = _mapper.MapToIEnumerableDto(result)
+            };
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "ItemAdjustmentListAsync failed {@command}", e.Message);
+            
+            return new ServiceResponse<IEnumerable<ItemForecastSpDto>>
+            {
+                Errors = [e.Message],
+                Message = ServiceMessageConstants.ItemForecastNotFound
+            };
+        }
+    }
+
+    public async Task<ServiceResponse> ImportAsync(ImportCommand serviceCommand)
+    {
+        try
+        {
+            var createdDate = DateTime.UtcNow;
+            var itemForecastCommands = ExcelHelper.ParseExcel(serviceCommand.Stream, row => new InsertItemForecastCommand
+            {
+                Room = row.Cell(1).TryGetValue(out int room) ? room : 0,
+                ItemId = row.Cell(2).Value.ToString(),
+                ForecastDate = row.Cell(9).TryGetValue(out DateTime validTo) ? validTo : DateTime.MinValue,
+                ForcedPrice = row.Cell(11).TryGetValue(out decimal exchangeRate) ? exchangeRate : 0
+            }).ToArray();
+            
+            if (itemForecastCommands.Length == 0)
+            {
+                throw new ServiceException(ServiceMessageConstants.ExchangeRateMustNotBeEmpty);
+            }
+            
+            var errors = new List<string>();
+            
+            if (itemForecastCommands.Any(x => x.Room <= 0))
+            {
+                var roomErrors = itemForecastCommands.Select((x, i) => new { x, i }).Where(x => x.x.Room < 1).Select(x => x.i).ToArray();
+                errors.Add($"{ServiceMessageConstants.ItemAdjustmentRoomInvalid}. Rows: {string.Join(", ", roomErrors.Take(10))}{(roomErrors.Length > 10 ? "..." : "")}");
+            }
+            
+            if (itemForecastCommands.Any(x => string.IsNullOrWhiteSpace(x.ItemId)))
+            {
+                var itemIdErrors = itemForecastCommands.Select((x, i) => new { x, i }).Where(x => string.IsNullOrWhiteSpace(x.x.ItemId)).Select(x => x.i + 2).ToArray();
+                errors.Add($"{ServiceMessageConstants.ItemForecastItemIdInvalid}. Rows: {string.Join(", ", itemIdErrors.Take(10))}{(itemIdErrors.Length > 10 ? "..." : "")}");
+            }
+            
+            if (itemForecastCommands.Any(x => x.ForecastDate == SqlDateTime.MinValue.Value))
+            {
+                var forecastDateErrors = itemForecastCommands.Select((x, i) => new { x, i }).Where(x => x.x.ForecastDate == DateTime.MinValue).Select(x => x.i + 2).ToArray();
+                errors.Add($"{ServiceMessageConstants.ItemForecastForecastDateInvalid}. Rows: {string.Join(", ", forecastDateErrors.Take(10))}{(forecastDateErrors.Length > 10 ? "..." : "")}");
+            }
+            
+            if (itemForecastCommands.Any(x => x.ForcedPrice == 0))
+            {
+                var forcedPriceErrors = itemForecastCommands.Select((x, i) => new { x, i }).Where(x => x.x.ForcedPrice == 0).Select(x => x.i + 2).ToArray();
+                errors.Add($"{ServiceMessageConstants.ItemForecastForcedPriceInvalid}. Rows: {string.Join(", ", forcedPriceErrors.Take(10))}{(forcedPriceErrors.Length > 10 ? "..." : "")}");
+            }
+            
+            if (errors.Count > 0)
+            {
+                return new ServiceResponse
+                {
+                    Errors = errors,
+                    Message = ServiceMessageConstants.ItemForecastImportValidationFailed
+                };
+            }
+
+            foreach (var command in itemForecastCommands)
+            {
+                await _unitOfWork.ItemForecastRepository.InsertItemForecastAsync(command);
+            }
+
+            _unitOfWork.CurrentTransaction?.Commit();
+
+            return new ServiceResponse
+            {
+                Message = ServiceMessageConstants.ItemForecastImportSuccess
+            };
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "ItemForecastImportAsync failed {@command}", e.Message);
+            
+            return new ServiceResponse
+            {
+                Errors = [e.Message],
+                Message = ServiceMessageConstants.ItemForecastImportFailed
+            };
+        }
+    }
+
+    public async Task<ServiceResponse<IEnumerable<int>>> GetItemForecastRoomIdsAsync()
+    {
+        try
+        {
+            var command = new GetItemForecastRoomIdsCommand();
+
+            var roomIds = await _unitOfWork.ItemForecastRepository.GetItemForecastRoomIdsAsync(command);
+
+            return new ServiceResponse<IEnumerable<int>>
+            {
+                Data = roomIds,
+                Message = ServiceMessageConstants.ItemForecastRoomIdsFound
+            };
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "GetItemForecastRoomIdsAsync failed {@command}", e.Message);
+            
+            return new ServiceResponse<IEnumerable<int>>
+            {
+                Errors = [e.Message],
+                Message = ServiceMessageConstants.ItemForecastRoomIdsNotFound
+            };
+        }
+    }
+}

--- a/Futurist.Service/MapperlyMapper.cs
+++ b/Futurist.Service/MapperlyMapper.cs
@@ -95,4 +95,12 @@ public partial class MapperlyMapper
     public partial IEnumerable<FgCostVerSpDto> MapToIEnumerableDto(IEnumerable<FgCostVerSp> entities);
     public partial PagedList<FgCostVerSp> MapToPagedList(PagedListDto<FgCostVerSpDto> dto);
     public partial PagedListDto<FgCostVerSpDto> MapToPagedListDto(PagedList<FgCostVerSp> entity);
+    
+    // ItemForecastSp
+    public partial ItemForecastSp MapToEntity(ItemForecastSpDto dto);
+    public partial ItemForecastSpDto MapToDto(ItemForecastSp entity);
+    public partial IEnumerable<ItemForecastSp> MapToIEnumerable(IEnumerable<ItemForecastSpDto> dtos);
+    public partial IEnumerable<ItemForecastSpDto> MapToIEnumerableDto(IEnumerable<ItemForecastSp> entities);
+    public partial PagedList<ItemForecastSp> MapToPagedList(PagedListDto<ItemForecastSpDto> dto);
+    public partial PagedListDto<ItemForecastSpDto> MapToPagedListDto(PagedList<ItemForecastSp> entity);
 }

--- a/Futurist.Service/ServiceCollectionExtensions.cs
+++ b/Futurist.Service/ServiceCollectionExtensions.cs
@@ -19,5 +19,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IExchangeRateService, ExchangeRateService>();
         services.AddScoped<IItemAdjustmentService, ItemAdjustmentService>();
         services.AddScoped<IFgCostVerService, FgCostVerService>();
+        services.AddScoped<IItemForecastService, ItemForecastService>();
     }
 }

--- a/Futurist.Web/Controllers/ItemForecastController.cs
+++ b/Futurist.Web/Controllers/ItemForecastController.cs
@@ -1,0 +1,177 @@
+﻿using Futurist.Common.Helpers;
+using Futurist.Repository.Command.ItemForecast;
+using Futurist.Service.Command.ItemForecastCommand;
+using Futurist.Service.Dto;
+using Futurist.Service.Interface;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Futurist.Web.Controllers;
+
+[Authorize]
+public class ItemForecastController : Controller
+{
+    private readonly IItemForecastService _service;
+
+    public ItemForecastController(IItemForecastService service)
+    {
+        _service = service;
+    }
+
+    // GET
+    public async Task<IActionResult> Index()
+    {
+        if (TempData["Success"] != null)
+        {
+            ViewBag.Success = TempData["Success"];
+        }
+        if (TempData["Errors"] != null)
+        {
+            ViewBag.Errors = TempData["Errors"];
+        }
+
+        var response = await _service.GetItemForecastRoomIdsAsync();
+        
+        if (response.IsSuccess)
+        {
+            ViewBag.RoomIds = response.Data;
+        }
+        else
+        {
+            ViewBag.Error = response.ErrorMessage;
+        }
+        
+        return View();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Import([FromForm(Name = "file")] IFormFile fileInput)
+    {
+        if (fileInput.Length == 0)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+        var command = new ImportCommand
+        {
+            Stream = fileInput.OpenReadStream(),
+            User = User.FindFirst("preferred_username")?.Value ?? "Unknown"
+        };
+
+        var response = await _service.ImportAsync(command);
+
+        if (response.IsSuccess)
+        {
+            TempData["Success"] = response.Message;
+        }
+        else
+        {
+            TempData["Errors"] = response.Errors;
+        }
+
+        return RedirectToAction("Index");
+    }
+    
+    [HttpGet]
+    public IActionResult DownloadTemplate()
+    {
+        var stream = ExcelHelper.CreateExcelTemplate(list =>
+        {
+            ArgumentNullException.ThrowIfNull(list);
+            list.Add(nameof(ItemForecastSpDto.Room));
+            list.Add(nameof(ItemForecastSpDto.ItemId));
+            list.Add(nameof(ItemForecastSpDto.ForecastDate));
+            list.Add(nameof(ItemForecastSpDto.ForcedPrice));
+        });
+        
+        return File(stream, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "ItemForecastTemplate.xlsx");
+    }
+    
+    [HttpGet]
+    public async Task<IActionResult> ExportItemForecast([FromQuery] int room)
+    {
+        var response = await _service.GetItemForecastListAsync(room);
+        
+        if (response is not { IsSuccess: true, Data: not null }) return BadRequest(response.Errors);
+        
+        var stream = ExcelHelper.ExportExcel(response.Data, (row, dto) =>
+        {
+            if (row.RowNumber() == 1)
+            {
+                row.Cell(1).Value = "Room";
+                row.Cell(2).Value = "Item Id";
+                row.Cell(3).Value = "Item Name";
+                row.Cell(4).Value = "Unit";
+                row.Cell(5).Value = "Group Substitusi";
+                row.Cell(6).Value = "Group Procurement";
+                row.Cell(7).Value = "Price";
+                row.Cell(8).Value = "Latest Purchase Date";
+                row.Cell(9).Value = "Forecast Date";
+                row.Cell(10).Value = "Forecast Price";
+                row.Cell(11).Value = "Forced Price";
+            }
+            else
+            {
+                row.Cell(1).Value = dto.Room;
+                row.Cell(2).Value = dto.ItemId;
+                row.Cell(3).Value = dto.ItemName;
+                row.Cell(4).Value = dto.UnitId;
+                row.Cell(5).Value = dto.VtaMpSubstitusiGroupId;
+                row.Cell(6).Value = dto.GroupProcurement;
+                row.Cell(7).Value = dto.Price;
+                row.Cell(7).Style.NumberFormat.Format = "#,##0";
+                row.Cell(8).Value = dto.LatestPurchaseDate;
+                row.Cell(8).Style.DateFormat.Format = "dd MMM yyyy";
+                row.Cell(9).Value = dto.ForecastDate;
+                row.Cell(9).Style.DateFormat.Format = "dd MMM yyyy";
+                row.Cell(10).Value = dto.ForecastPrice;
+                row.Cell(10).Style.NumberFormat.Format = "#,##0";
+                row.Cell(11).Value = dto.ForcedPrice;
+                row.Cell(11).Style.NumberFormat.Format = "#,##0";
+            }
+        });
+        
+        return File(stream, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"ItemForecast_{DateTime.Now:yyyyMMddHHmmss}.xlsx");
+    }
+    
+}
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]/[action]")]
+public class ItemForecastApiController : ControllerBase
+{
+    private readonly IItemForecastService _itemForecastService;
+
+    public ItemForecastApiController(IItemForecastService itemForecastService)
+    {
+        _itemForecastService = itemForecastService;
+    }
+
+    [HttpGet]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> GetItemForecastList([FromQuery] int room)
+    {
+        var response = await _itemForecastService.GetItemForecastListAsync(room);
+
+        if (response.IsSuccess)
+        {
+            return Ok(response);
+        }
+
+        return BadRequest(response);
+    }
+    
+    [HttpGet]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> GetItemForecastRoomIds()
+    {
+        var response = await _itemForecastService.GetItemForecastRoomIdsAsync();
+
+        if (response.IsSuccess)
+        {
+            return Ok(response.Data);
+        }
+
+        return BadRequest(response.Errors);
+    }
+}

--- a/Futurist.Web/Views/ItemForecast/Index.cshtml
+++ b/Futurist.Web/Views/ItemForecast/Index.cshtml
@@ -1,0 +1,259 @@
+﻿@model Futurist.Service.Dto.Common.ServiceResponse<List<Futurist.Service.Dto.ItemForecastSpDto>>
+
+@{
+    ViewBag.Title = "Item Forecast Summary";
+    ViewBag.pTitle = "Item Forecast Summary";
+    ViewBag.pageTitle = "Pages";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+@section styles{
+    <link href="/assets/css/datatables.min.css" rel="stylesheet">
+}
+
+@Html.AntiForgeryToken()
+
+<div class="row">
+    <div class="col-12">
+        @if (ViewBag.Error != null)
+        {
+            <div class="alert alert-danger mb-xl-0" role="alert">
+                @ViewBag.Error
+            </div>
+        }
+        @if (ViewBag.Errors != null)
+        {
+            @foreach(var error in ViewBag.Errors)
+            {
+                <div class="alert alert-danger mb-xl-0" role="alert">
+                    @error
+                </div>
+            }
+        }
+        @if (ViewBag.Success != null)
+        {
+            <div class="alert alert-success mb-xl-0" role="alert">
+                @ViewBag.Success
+            </div>
+        }
+    </div>
+</div>
+                
+<div class="row">
+    <div class="col-lg-12">
+        <div class="card">
+            <div class="card-header">
+                <h1 class="mb-3">Item Forecast Summary</h1>
+
+                <div class="input-group mb-3">
+                    <label class="input-group-text" for="roomSelect">Room</label>
+                    <select id="roomSelect" name="roomId" class="form-control">
+                        @if (ViewBag.RoomIds != null)
+                        {
+                            @foreach (var room in ViewBag.RoomIds)
+                            {
+                                <option value="@room">@room</option>
+                            }
+                        }
+                    </select>
+                </div>
+
+                <div class="d-flex justify-content-between">
+                    <form asp-controller="ItemForecast" asp-action="Import" method="post" enctype="multipart/form-data">
+                        <div class="input-group">
+                            <input type="file" id="fileInput" name="file" class="form-control" aria-describedby="fileInputAddon" aria-label="Upload" accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" required>
+                            <button type="submit" class="btn btn-outline-success material-shadow-none" id="fileInputAddon">
+                                <span class="ri-upload-2-fill me-1"></span>
+                                Upload
+                            </button>
+                        </div>
+                    </form>
+                    <div>
+                        <button class="btn btn-primary" id="checkMupBtn" onclick="reloadTable()">
+                            <i class="ri-refresh-line"></i>
+                            Refresh Table
+                        </button>
+                        <a asp-controller="ItemForecast" asp-action="ExportItemForecast" asp-route-room="0" onclick="downloadItemForecast()" id="linkDownload" class="btn btn-info">
+                            <i class="ri-file-excel-2-fill"></i>
+                            Download Result
+                        </a>
+                    </div>
+                </div>
+            </div><!-- end card header -->
+
+            <div class="card-body">
+                <table id="datatables-item-adjustments" class="display table table-bordered dt-responsive datatable-wrapper" style="width:100%">
+                    <thead>
+                    <tr>
+                        <th>Room</th>
+                        <th>Item ID</th>
+                        <th>Item Name</th>
+                        <th>Unit</th>
+                        <th>Group Substitusi</th>
+                        <th>Group Procurement</th>
+                        <th>Price</th>
+                        <th>Latest Purchase Date</th>
+                        <th>Forecast Date</th>
+                        <th>Forecast Price</th>
+                        <th>Forced Price</th>
+                    </tr>
+                    </thead>
+                    <tfoot>
+                        <tr>
+                            <th>Room</th>
+                            <th>Item ID</th>
+                            <th>Item Name</th>
+                            <th>Unit</th>
+                            <th>Group Substitusi</th>
+                            <th>Group Procurement</th>
+                            <th>Price</th>
+                            <th>Latest Purchase Date</th>
+                            <th>Forecast Date</th>
+                            <th>Forecast Price</th>
+                            <th>Forced Price</th>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div><!-- end card-body -->
+        </div><!-- end card -->
+    </div>
+    <!-- end col -->
+</div>
+<!-- end row -->
+            
+@section scripts{
+    <script src="/assets/js/datatables.min.js"></script>
+
+    <script>
+        // get AntiForgeryToken using jquery
+        const token = $('input[name="__RequestVerificationToken"]').val();
+        const roomSelect = $("#roomSelect");
+
+        // Debounce helper function
+        function debounce(func, delay) {
+            let timeout;
+            return function(...args) {
+                clearTimeout(timeout);
+                timeout = setTimeout(() => func.apply(this, args), delay);
+            };
+        }
+
+        function reloadTable() {
+            $('#datatables-item-adjustments').DataTable().ajax.reload();
+        }
+
+        roomSelect.change(function () {
+            reloadTable();
+        });
+
+        function downloadItemForecast() {
+            // change the room id in the download link
+            const room = roomSelect.val();
+            const linkDownload = $("#linkDownload")[0];
+            // edit the query room
+            linkDownload.href = linkDownload.href.replace(/room=\d+/, `room=${room}`);
+        }
+
+        $(document).ready(function() {
+            $('#datatables-item-adjustments').DataTable({
+                searchDelay: 1000,
+                ajax: {
+                    url: `/api/ItemForecastApi/GetItemForecastList`,
+                    data: function(d) {
+                        // Get room id from dropdown
+                        return { room: $("#roomSelect").val() };
+                    },
+                    beforeSend: function(xhr) {
+                        xhr.setRequestHeader("RequestVerificationToken", token);
+                    },
+                    dataSrc: function(json) {
+                        if (json.data && Array.isArray(json.data)) {
+                            return json.data;
+                        }
+                        return [];
+                    }
+                },
+                columns: [
+                    { data: 'room', width: '80px' },
+                    { data: 'itemId', width: '120px' },
+                    { data: 'itemName' },
+                    { data: 'unitId', width: '80px' },
+                    { data: 'vtaMpSubstitusiGroupId', width: '150px' },
+                    { data: 'groupProcurement', width: '150px' },
+                    { 
+                        data: 'price', 
+                        width: '100px',
+                        render: function(data, type) {
+                            return data ? Intl.NumberFormat('en-US', { style: 'decimal', maximumFractionDigits: 0, minimumFractionDigits: 0 }).format(parseFloat(data)) : '';
+                        }
+                    },
+                    { 
+                        data: 'latestPurchaseDate', 
+                        width: '150px',
+                        render: function(data) {
+                            return moment(data).format("DD MMM YYYY");
+                        },
+                    },
+                    { 
+                        data: 'forecastDate', 
+                        width: '150px',
+                        render: function(data) {
+                            return moment(data).format("DD MMM YYYY");
+                        },
+                    },
+                    { 
+                        data: 'forecastPrice', 
+                        width: '100px',
+                        render: function(data, type) {
+                            return data ? Intl.NumberFormat('en-US', { style: 'decimal', maximumFractionDigits: 0, minimumFractionDigits: 0 }).format(parseFloat(data)) : '';
+                        }
+                    },
+                    { 
+                        data: 'forcedPrice', 
+                        width: '100px',
+                        render: function(data, type) {
+                            return data != null ? Intl.NumberFormat('en-US', { style: 'decimal', maximumFractionDigits: 0, minimumFractionDigits: 0 }).format(parseFloat(data)) : '';
+                        }
+                    }
+                ],
+                columnDefs: [
+                    {
+                        targets: [0, 1, 3, 4, 6],
+                        className: 'text-center'
+                    }
+                ],
+                processing: true,
+                paging: true,
+                searching: true,
+                ordering: true,
+                autoWidth: false,
+                responsive: true,
+                scrollX: true,
+                initComplete: function () {
+                    this.api()
+                        .columns()
+                        .every(function () {
+                            let column = this;
+                            let title = column.footer().textContent;
+
+                            let header = column.header();
+                            header.style.backgroundColor = '#4F81BD';
+                            header.style.color = 'white';
+
+                            let input = document.createElement('input');
+                            input.placeholder = title;
+                            input.className = "form-control";
+                            input.style.width = '100%';
+                            column.footer().replaceChildren(input);
+
+                            input.addEventListener('keyup', debounce(() => {
+                                if (column.search() !== input.value) {
+                                    column.search(input.value).draw();
+                                }
+                            }, 1000));
+                        });
+                }
+            });
+        });
+    </script>
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing item forecasts, including the addition of new domain models, commands, repositories, services, and associated mappings. The changes are grouped thematically into domain modeling, repository implementation, service layer additions, and supporting utilities.

### Domain Modeling
* Added the `ItemForecastSp` class to represent item forecast data, including properties such as `Room`, `ItemId`, `ForecastDate`, and `ForcedPrice`. (`[Futurist.Domain/ItemForecastSp.csR1-R18](diffhunk://#diff-5c108af7032401372c270b64b9b69be74c82f97d6d083f459c227aee74e2e8b5R1-R18)`)

### Repository Implementation
* Created commands for item forecast operations:
  - `GetItemForecastListCommand` for fetching forecasts by room. (`[Futurist.Repository.Command/ItemForecast/GetItemForecastListCommand.csR1-R6](diffhunk://#diff-8f2103ce0a38b069a8d7da6f916651faa3e8c99d86f4132441798bc8fd2db410R1-R6)`)
  - `GetItemForecastRoomIdsCommand` for retrieving distinct room IDs. (`[Futurist.Repository.Command/ItemForecast/GetItemForecastRoomIdsCommand.csR1-R3](diffhunk://#diff-286cc35686b6978e6f02b3882bef9bf624c6a457a86d03c62056f60c403cb4d8R1-R3)`)
  - `InsertItemForecastCommand` for inserting new forecasts. (`[Futurist.Repository.Command/ItemForecast/InsertItemForecastCommand.csR1-R14](diffhunk://#diff-4006bbc6bb21bd1ebc9dd41d6908f678966be488c5e7112999591e7980b11e01R1-R14)`)
* Implemented `IItemForecastRepository` interface with methods for fetching, inserting, and retrieving room IDs. (`[Futurist.Repository.Interface/IItemForecastRepository.csR1-R11](diffhunk://#diff-076ad243034575358a4b2a960937aa44230cade6ed5bb9bdb11ecc5ad1671674R1-R11)`)
* Added `ItemForecastRepository` to execute SQL operations using Dapper, including stored procedures and custom queries. (`[Futurist.Repository.SqlServer/ItemForecastRepository.csR1-R85](diffhunk://#diff-b90f4056e96b05e7097add264ff9708e2ce88132c9127bfd9779f74390ea820eR1-R85)`)

### Service Layer Additions
* Introduced the `IItemForecastService` interface and `ItemForecastService` implementation to handle business logic for operations such as fetching forecasts, importing data, and retrieving room IDs. (`[[1]](diffhunk://#diff-edd1c96411ff1f282479ed43f7039105e5d947423f4fc3b84a6e03ef28f0a2c8R1-R12)`, `[[2]](diffhunk://#diff-107505b199a93ec75bfddae10da1d01a64cbf5f4d136c167f86b8a9394784496R1-R155)`)
* Added `ImportCommand` to encapsulate import operations with properties for input streams and user identifiers. (`[Futurist.Service.Command/ItemForecastCommand/ImportCommand.csR1-R7](diffhunk://#diff-15a58f58d1d3b17bf01c444262dd260dd19a767fe375e554ebdf2c8a64c0a3b0R1-R7)`)

### Supporting Utilities
* Extended `MapperlyMapper` to include mappings for `ItemForecastSp` and `ItemForecastSpDto` for seamless data transformation. (`[Futurist.Service/MapperlyMapper.csR98-R105](diffhunk://#diff-c85eb60c56f01182b94acd4730d56571061bd82f06074b4d027c3183b6aa2b92R98-R105)`)
* Updated `ServiceMessageConstants` with new constants for item forecast-related messages, such as validation errors and operation success. (`[Futurist.Service.Dto/Common/ServiceMessageConstants.csR77-R85](diffhunk://#diff-cfcb20f2c6fb924a72830913f99cfb047d7151c0e3f129f8eb78e895f629ba6dR77-R85)`)
* Registered `IItemForecastService` in the service collection for dependency injection. (`[Futurist.Service/ServiceCollectionExtensions.csR22](diffhunk://#diff-3dbb79de6356c87e24c6decc1466bc00a6726d4ed5584acc139bb29ec947df5aR22)`)