### PR TITLE
feat(ServiceCollection): Register IItemForecastRepository in service collection

### DIFF
--- a/Futurist.Repository.SqlServer/ServiceCollectionExtensions.cs
+++ b/Futurist.Repository.SqlServer/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IExchangeRateRepository, ExchangeRateRepository>();
         services.AddScoped<IItemAdjustmentRepository, ItemAdjustmentRepository>();
         services.AddScoped<IFgCostVerRepository, FgCostVerRepository>();
+        services.AddScoped<IItemForecastRepository, ItemForecastRepository>();
         
         services.AddScoped<IDbConnection>(s =>
         {


### PR DESCRIPTION
This pull request adds a new repository registration to the `AddRepositorySqlServer` extension method in `ServiceCollectionExtensions.cs`. 

Dependency Injection Update:

* [`Futurist.Repository.SqlServer/ServiceCollectionExtensions.cs`](diffhunk://#diff-734c0b3b67a1e61653866ff774300f023cfa5f5e7b0c2476fb4dfc115e369b92R24): Registered the `IItemForecastRepository` interface with its implementation, `ItemForecastRepository`, to the service collection. This ensures that `IItemForecastRepository` can be resolved via dependency injection.