### PR TITLE
feat(Mup): Add GroupProcurement and OriginalCurrency properties, update related functionality in DTOs and views

### DIFF
--- a/Futurist.Domain/MupSp.cs
+++ b/Futurist.Domain/MupSp.cs
@@ -13,6 +13,7 @@ public class MupSp
     public string ItemId { get; set; } = string.Empty;
     public string ItemName { get; set; } = string.Empty;
     public string GroupSubstitusi { get; set; } = string.Empty;
+    public string GroupProcurement { get; set; } = string.Empty;
     public string ItemAllocatedId { get; set; } = string.Empty;
     public string ItemAllocatedName { get; set; } = string.Empty;
     public string UnitId { get; set; } = string.Empty;
@@ -23,6 +24,7 @@ public class MupSp
     public decimal PmPrice { get; set; }
     public decimal StdCostPrice { get; set; }
     public string Source { get; set; } = string.Empty;
+    public string OriginalCurrency { get; set; } = string.Empty;
     public string RefId { get; set; } = string.Empty;
     public decimal LatestPurchasePrice { get; set; }
     public decimal Gap { get; set; }

--- a/Futurist.Service.Dto/MupSpDto.cs
+++ b/Futurist.Service.Dto/MupSpDto.cs
@@ -22,6 +22,8 @@ public class MupSpDto
     public string ItemName { get; set; } = string.Empty;
     [DisplayName("Group Substitusi")]
     public string GroupSubstitusi { get; set; } = string.Empty;
+    [DisplayName("Group Procurement")]
+    public string GroupProcurement { get; set; } = string.Empty;
     [DisplayName("Item Allocated ID")]
     public string ItemAllocatedId { get; set; } = string.Empty;
     [DisplayName("Item Allocated Name")]
@@ -36,6 +38,8 @@ public class MupSpDto
     public decimal Price { get; set; }
     [DisplayName("Source")]
     public string Source { get; set; } = string.Empty;
+    [DisplayName("Original Currency")]
+    public string OriginalCurrency { get; set; } = string.Empty;
     [DisplayName("Ref ID")]
     public string RefId { get; set; } = string.Empty;
     [DisplayName("Latest Purchase Price")]

--- a/Futurist.Web/Controllers/MupController.cs
+++ b/Futurist.Web/Controllers/MupController.cs
@@ -118,16 +118,18 @@ public class MupController : Controller
                 row.Cell(6).Value = "Item Id";
                 row.Cell(7).Value = "Item Name";
                 row.Cell(8).Value = "Group Substitusi";
-                row.Cell(9).Value = "Item Allocated Id";
-                row.Cell(10).Value = "Item Allocated Name";
-                row.Cell(11).Value = "Unit Id";
-                row.Cell(12).Value = "Batch";
-                row.Cell(13).Value = "Qty";
-                row.Cell(14).Value = "Price";
-                row.Cell(15).Value = "Source";
-                row.Cell(16).Value = "Ref Id";
-                row.Cell(17).Value = "Latest Purchase Price";
-                row.Cell(18).Value = "Gap";
+                row.Cell(9).Value = "Group Procurement";
+                row.Cell(10).Value = "Item Allocated Id";
+                row.Cell(11).Value = "Item Allocated Name";
+                row.Cell(12).Value = "Unit";
+                row.Cell(13).Value = "Batch";
+                row.Cell(14).Value = "Qty";
+                row.Cell(15).Value = "Price";
+                row.Cell(16).Value = "Source";
+                row.Cell(17).Value = "Original Currency";
+                row.Cell(18).Value = "Ref Id";
+                row.Cell(19).Value = "Latest Purchase Price";
+                row.Cell(20).Value = "Gap";
             }
             else
             {
@@ -137,24 +139,26 @@ public class MupController : Controller
                 row.Cell(4).Value = dto.RofoDate;
                 row.Cell(4).Style.NumberFormat.Format = "dd MMM yyyy";
                 row.Cell(5).Value = dto.QtyRofo;
-                row.Cell(5).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+                row.Cell(5).Style.NumberFormat.Format = "#,##0";
                 row.Cell(6).Value = dto.ItemId;
                 row.Cell(7).Value = dto.ItemName;
                 row.Cell(8).Value = dto.GroupSubstitusi;
-                row.Cell(9).Value = dto.ItemAllocatedId;
-                row.Cell(10).Value = dto.ItemAllocatedName;
-                row.Cell(11).Value = dto.UnitId;
-                row.Cell(12).Value = dto.InventBatch;
-                row.Cell(13).Value = dto.Qty;
-                row.Cell(13).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Precision2WithSeparatorAndParens;
-                row.Cell(14).Value = dto.Price;
-                row.Cell(14).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
-                row.Cell(15).Value = dto.Source;
-                row.Cell(16).Value = dto.RefId;
-                row.Cell(17).Value = dto.LatestPurchasePrice;
-                row.Cell(17).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
-                row.Cell(18).Value = dto.Gap;
-                row.Cell(18).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Integer;
+                row.Cell(9).Value = dto.GroupProcurement;
+                row.Cell(10).Value = dto.ItemAllocatedId;
+                row.Cell(11).Value = dto.ItemAllocatedName;
+                row.Cell(12).Value = dto.UnitId;
+                row.Cell(13).Value = dto.InventBatch;
+                row.Cell(14).Value = dto.Qty;
+                row.Cell(14).Style.NumberFormat.Format = "#,##0.00";
+                row.Cell(15).Value = dto.Price;
+                row.Cell(15).Style.NumberFormat.Format = "#,##0";
+                row.Cell(16).Value = dto.Source;
+                row.Cell(17).Value = dto.OriginalCurrency;
+                row.Cell(18).Value = dto.RefId;
+                row.Cell(19).Value = dto.LatestPurchasePrice;
+                row.Cell(19).Style.NumberFormat.Format = "#,##0";
+                row.Cell(20).Value = dto.Gap;
+                row.Cell(20).Style.NumberFormat.Format = "#,##0.0%";
             }
         });
         
@@ -164,15 +168,7 @@ public class MupController : Controller
     
     public async Task<IActionResult> DownloadMupSummaryByItemId([FromQuery] int room)
     {
-        var listRequestDto = new ListRequestDto
-        {
-            Filters = new Dictionary<string, string>
-            {
-                { "Room", room.ToString() }
-            }
-        };
-        
-        var response = await _mupService.MupSummaryByItemIdAsync(listRequestDto);
+        var response = await _mupService.MupSummaryByItemIdFromSpAsync(room);
 
         if (response is not { IsSuccess: true, Data: not null }) return BadRequest(response.Errors);
         
@@ -180,24 +176,28 @@ public class MupController : Controller
         {
             if (row.RowNumber() == 1)
             {
-                row.Cell(1).Value = "Mup Date";
-                row.Cell(2).Value = "Group Substitusi";
-                row.Cell(3).Value = "Item Id";
-                row.Cell(4).Value = "Item Name";
-                row.Cell(5).Value = "Qty";
-                row.Cell(6).Value = "Price";
+                row.Cell(1).Value = "Room";
+                row.Cell(2).Value = "Mup Date";
+                row.Cell(3).Value = "Group Substitusi";
+                row.Cell(4).Value = "Group Procurement"; // added header
+                row.Cell(5).Value = "Item Id";
+                row.Cell(6).Value = "Item Name";
+                row.Cell(7).Value = "Qty";
+                row.Cell(8).Value = "Price";
             }
             else
             {
-                row.Cell(1).Value = dto.MupDate;
-                row.Cell(1).Style.NumberFormat.Format = "dd MMM yyyy";
-                row.Cell(2).Value = dto.GroupSubstitusi;
-                row.Cell(3).Value = dto.ItemId;
-                row.Cell(4).Value = dto.ItemName;
-                row.Cell(5).Value = dto.Qty;
-                row.Cell(5).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Precision2WithSeparatorAndParens;
-                row.Cell(6).Value = dto.Price;
-                row.Cell(6).Style.NumberFormat.Format = "#,##0";
+                row.Cell(1).Value = dto.Room;
+                row.Cell(2).Value = dto.MupDate;
+                row.Cell(2).Style.NumberFormat.Format = "dd MMM yyyy";
+                row.Cell(3).Value = dto.GroupSubstitusi;
+                row.Cell(4).Value = dto.GroupProcurement; // added mapping
+                row.Cell(5).Value = dto.ItemId;
+                row.Cell(6).Value = dto.ItemName;
+                row.Cell(7).Value = dto.Qty;
+                row.Cell(7).Style.NumberFormat.Format = "#,##0.00";
+                row.Cell(8).Value = dto.Price;
+                row.Cell(8).Style.NumberFormat.Format = "#,##0";
             }
         });
         
@@ -207,15 +207,7 @@ public class MupController : Controller
 
     public async Task<IActionResult> DownloadMupSummaryByBatchNumber([FromQuery] int room)
     {
-        var listRequestDto = new ListRequestDto
-        {
-            Filters = new Dictionary<string, string>
-            {
-                { "Room", room.ToString() }
-            }
-        };
-        
-        var response = await _mupService.MupSummaryByBatchNumberAsync(listRequestDto);
+        var response = await _mupService.MupSummaryByBatchNumberFromSpAsync(room);
         
         if (response is not { IsSuccess: true, Data: not null }) return BadRequest(response.Errors);
         
@@ -223,35 +215,40 @@ public class MupController : Controller
         {
             if (row.RowNumber() == 1)
             {
-                row.Cell(1).Value = "MUP Date";
-                row.Cell(2).Value = "Source";
-                row.Cell(3).Value = "Group Substitusi";
-                row.Cell(4).Value = "Item Allocated ID";
-                row.Cell(5).Value = "Item Allocated Name";
-                row.Cell(6).Value = "Unit";
-                row.Cell(7).Value = "Batch";
-                row.Cell(8).Value = "Qty";
-                row.Cell(9).Value = "Price";
-                row.Cell(10).Value = "Latest Purchase Price";
-                row.Cell(11).Value = "Gap";
+                row.Cell(1).Value = "Room";
+                row.Cell(2).Value = "MUP Date";
+                row.Cell(3).Value = "Source";
+                row.Cell(4).Value = "Group Substitusi";
+                row.Cell(5).Value = "Group Procurement"; // added header
+                row.Cell(6).Value = "Item Allocated ID";
+                row.Cell(7).Value = "Item Allocated Name";
+                row.Cell(8).Value = "Unit";
+                row.Cell(9).Value = "Batch";
+                row.Cell(10).Value = "Qty";
+                row.Cell(11).Value = "Price";
+                row.Cell(12).Value = "Latest Purchase Price";
+                row.Cell(13).Value = "Gap";
             }
             else
             {
-                row.Cell(1).Value = dto.MupDate;
-                row.Cell(2).Value = dto.Source;
-                row.Cell(3).Value = dto.GroupSubstitusi;
-                row.Cell(4).Value = dto.ItemAllocatedId;
-                row.Cell(5).Value = dto.ItemAllocatedName;
-                row.Cell(6).Value = dto.UnitId;
-                row.Cell(7).Value = dto.InventBatch;
-                row.Cell(8).Value = dto.Qty;
-                row.Cell(8).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Precision2WithSeparatorAndParens;
-                row.Cell(9).Value = dto.Price;
-                row.Cell(9).Style.NumberFormat.Format = "#,##0";
-                row.Cell(10).Value = dto.LatestPurchasePrice;
-                row.Cell(10).Style.NumberFormat.Format = "#,##0";
-                row.Cell(11).Value = dto.Gap;
-                row.Cell(11).Style.NumberFormat.Format = "#,##0.0%";
+                row.Cell(1).Value = dto.Room;
+                row.Cell(2).Value = dto.MupDate;
+                row.Cell(2).Style.DateFormat.Format = "dd MMM yyyy";
+                row.Cell(3).Value = dto.Source;
+                row.Cell(4).Value = dto.GroupSubstitusi;
+                row.Cell(5).Value = dto.GroupProcurement; // added mapping
+                row.Cell(6).Value = dto.ItemAllocatedId;
+                row.Cell(7).Value = dto.ItemAllocatedName;
+                row.Cell(8).Value = dto.UnitId;
+                row.Cell(9).Value = dto.InventBatch;
+                row.Cell(10).Value = dto.Qty;
+                row.Cell(10).Style.NumberFormat.Format = "#,##0.00";
+                row.Cell(11).Value = dto.Price;
+                row.Cell(11).Style.NumberFormat.Format = "#,##0";
+                row.Cell(12).Value = dto.LatestPurchasePrice;
+                row.Cell(12).Style.NumberFormat.Format = "#,##0";
+                row.Cell(13).Value = dto.Gap;
+                row.Cell(13).Style.NumberFormat.Format = "#,##0.0%";
             }
         });
         

--- a/Futurist.Web/Views/Mup/Details.cshtml
+++ b/Futurist.Web/Views/Mup/Details.cshtml
@@ -39,7 +39,7 @@
                     </button>
                     <a asp-controller="Mup" asp-action="DownloadMupResult" asp-route-room="0" onclick="downloadMup()" id="linkDownload" class="btn btn-info">
                         <i class="ri-file-excel-2-fill"></i>
-                        Export Result
+                        Download Result
                     </a>
                 </div>
             </div>
@@ -55,6 +55,7 @@
                         <th>Item ID</th>
                         <th>Item Name</th>
                         <th>Group Substitusi</th>
+                        <th>Group Procurement</th>
                         <th>Item Allocated ID</th>
                         <th>Item Allocated Name</th>
                         <th>Unit</th>
@@ -62,6 +63,7 @@
                         <th>Qty</th>
                         <th>Price</th>
                         <th>Source</th>
+                        <th>Original Currency</th>
                         <th>Ref ID</th>
                         <th>Latest Purchase Price</th>
                         <th>Gap</th>
@@ -77,6 +79,7 @@
                         <th>Item ID</th>
                         <th>Item Name</th>
                         <th>Group Substitusi</th>
+                        <th>Group Procurement</th>
                         <th>Item Allocated ID</th>
                         <th>Item Allocated Name</th>
                         <th>Unit</th>
@@ -84,6 +87,7 @@
                         <th>Qty</th>
                         <th>Price</th>
                         <th>Source</th>
+                        <th>Original Currency</th>
                         <th>Ref ID</th>
                         <th>Latest Purchase Price</th>
                         <th>Gap</th>
@@ -208,12 +212,13 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {data: 'itemId', defaultContent: ''},
                             {data: 'itemName', width: '200px', defaultContent: ''},
                             {data: 'groupSubstitusi', defaultContent: ''},
+                            {data: 'groupProcurement', defaultContent: ''},
                             {data: 'itemAllocatedId', defaultContent: ''},
                             {data: 'itemAllocatedName', width: '200px', defaultContent: ''},
                             {data: 'unitId', defaultContent: ''},
@@ -241,10 +246,11 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {data: 'source', defaultContent: ''},
+                            {data: 'originalCurrency', defaultContent: ''},
                             {data: 'refId', defaultContent: ''},
                             {
                                 data: 'latestPurchasePrice',
@@ -256,7 +262,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {

--- a/Futurist.Web/Views/Mup/Index.cshtml
+++ b/Futurist.Web/Views/Mup/Index.cshtml
@@ -51,7 +51,7 @@
                     </div>
                     <a asp-controller="Mup" asp-action="DownloadMupResult" asp-route-room="0" onclick="downloadMup()" id="linkDownload" class="btn btn-info">
                         <i class="ri-file-excel-2-fill"></i>
-                        Export Result
+                        Download Result
                     </a>
                 </div>
             </div>
@@ -298,7 +298,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { data: 'itemId', defaultContent: '' },
@@ -331,7 +331,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { data: 'source', defaultContent: '' },
@@ -346,7 +346,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     },
                     { 
@@ -359,7 +359,7 @@
                             }
 
                             // For display, round and format with thousands separator
-                            return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                            return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                         }
                     }
                 ],

--- a/Futurist.Web/Views/Mup/SummaryByBatchNumber.cshtml
+++ b/Futurist.Web/Views/Mup/SummaryByBatchNumber.cshtml
@@ -39,7 +39,7 @@
                     </button>
                     <a asp-controller="Mup" asp-action="DownloadMupSummaryByBatchNumber" asp-route-room="0" onclick="downloadMup()" id="linkDownload" class="btn btn-info">
                         <i class="ri-file-excel-2-fill"></i>
-                        Export Result
+                        Download Result
                     </a>
                 </div>
             </div>
@@ -51,6 +51,7 @@
                         <th>MUP Date</th>
                         <th>Source</th>
                         <th>Group Substitusi</th>
+                        <th>Group Procurement</th> <!-- added header -->
                         <th>Item Allocated ID</th>
                         <th>Item Allocated Name</th>
                         <th>Unit</th>
@@ -67,6 +68,7 @@
                         <th>MUP Date</th>
                         <th>Source</th>
                         <th>Group Substitusi</th>
+                        <th>Group Procurement</th> <!-- added footer -->
                         <th>Item Allocated ID</th>
                         <th>Item Allocated Name</th>
                         <th>Unit</th>
@@ -210,6 +212,7 @@
                             },
                             { data: 'source', defaultContent: '' },
                             { data: 'groupSubstitusi', defaultContent: '' },
+                            { data: 'groupProcurement', defaultContent: '' }, // added column
                             { data: 'itemAllocatedId', defaultContent: '' },
                             { data: 'itemAllocatedName', width: '200px', defaultContent: '' },
                             { data: 'unitId', defaultContent: '' },
@@ -237,7 +240,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {
@@ -250,7 +253,7 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             },
                             {

--- a/Futurist.Web/Views/Mup/SummaryByItemId.cshtml
+++ b/Futurist.Web/Views/Mup/SummaryByItemId.cshtml
@@ -39,7 +39,7 @@
                     </button>
                     <a asp-controller="Mup" asp-action="DownloadMupSummaryByItemId" asp-route-room="0" onclick="downloadMup()" id="linkDownload" class="btn btn-info">
                         <i class="ri-file-excel-2-fill"></i>
-                        Export Result
+                        Download Result
                     </a>
                 </div>
             </div>
@@ -50,6 +50,7 @@
                         <th>Room</th>
                         <th>MUP Date</th>
                         <th>Group Substitusi</th>
+                        <th>Group Procurement</th>
                         <th>Item Allocated ID</th>
                         <th>Item Name</th>
                         <th>Qty</th>
@@ -61,6 +62,7 @@
                         <th>Room</th>
                         <th>MUP Date</th>
                         <th>Group Substitusi</th>
+                        <th>Group Procurement</th>
                         <th>Item Allocated ID</th>
                         <th>Item Name</th>
                         <th>Qty</th>
@@ -187,6 +189,7 @@
                                 }
                             },
                             { data: 'groupSubstitusi', width: '120px', defaultContent: '' },
+                            { data: 'groupProcurement', width: '120px', defaultContent: '' }, // added column
                             { data: 'itemAllocatedId', width: '70px', defaultContent: '' },
                             { data: 'itemName', width: '250px', defaultContent: '' },
                             {
@@ -214,13 +217,13 @@
                                     }
 
                                     // For display, round and format with thousands separator
-                                    return data ? Math.round(parseFloat(data)).toLocaleString() : '';
+                                    return data ? Intl.NumberFormat("en-US", { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(data) : '';
                                 }
                             }
                         ],
                         columnDefs: [
                             {
-                                targets: [0, 2, 3], // MUP Date, Qty, Price
+                                targets: [0, 2, 3], // ensure room, groupSubstitusi & groupProcurement are centered
                                 className: 'text-center'
                             }
                         ],


### PR DESCRIPTION
This pull request introduces enhancements to the `Mup` module by adding new fields, improving data formatting, and updating export functionality. The changes include the addition of `GroupProcurement` and `OriginalCurrency` fields, updates to Excel export headers and mappings, and improved number formatting in the UI.

### Enhancements to Data Models:
* Added `GroupProcurement` and `OriginalCurrency` properties to the `MupSp` class (`Futurist.Domain/MupSp.cs`) and their corresponding DTO class `MupSpDto` (`Futurist.Service.Dto/MupSpDto.cs`). (`[[1]](diffhunk://#diff-741ca1ceaca5cfbc9a2d9892cf3258451cf9d5e7cfe62d14cf36f595c249f7b0R16)`, `[[2]](diffhunk://#diff-741ca1ceaca5cfbc9a2d9892cf3258451cf9d5e7cfe62d14cf36f595c249f7b0R27)`, `[[3]](diffhunk://#diff-6871caf1a52a6e3f8daca2f8e534390214b3b8a596f7fa8dd9cc2031f30f0fa6R25-R26)`, `[[4]](diffhunk://#diff-6871caf1a52a6e3f8daca2f8e534390214b3b8a596f7fa8dd9cc2031f30f0fa6R41-R42)`)

### Updates to Excel Export:
* Updated headers and mappings in the `DownloadMupResult`, `DownloadMupSummaryByItemId`, and `DownloadMupSummaryByBatchNumber` actions to include `GroupProcurement` and `OriginalCurrency`, and modified number formatting for better readability. (`[[1]](diffhunk://#diff-9fb61304c01d7bd1352b910aaba644ee2f7d010747f46d47a4eca877f5c6c3a1L121-R132)`, `[[2]](diffhunk://#diff-9fb61304c01d7bd1352b910aaba644ee2f7d010747f46d47a4eca877f5c6c3a1L140-R161)`, `[[3]](diffhunk://#diff-9fb61304c01d7bd1352b910aaba644ee2f7d010747f46d47a4eca877f5c6c3a1L167-R200)`, `[[4]](diffhunk://#diff-9fb61304c01d7bd1352b910aaba644ee2f7d010747f46d47a4eca877f5c6c3a1L210-R251)`)

### UI Improvements:
* Updated table headers in `Details.cshtml` and `Index.cshtml` to include `GroupProcurement` and `OriginalCurrency` fields. (`[[1]](diffhunk://#diff-9a9d9da2fc02aebe484b6b984b510589bbf5015c2c0e89335aa07f06c958258fR58-R66)`, `[[2]](diffhunk://#diff-9a9d9da2fc02aebe484b6b984b510589bbf5015c2c0e89335aa07f06c958258fR82-R90)`)
* Enhanced number formatting in the UI to use `Intl.NumberFormat` for consistent decimal and thousands separator handling. (`[[1]](diffhunk://#diff-9a9d9da2fc02aebe484b6b984b510589bbf5015c2c0e89335aa07f06c958258fL211-R221)`, `[[2]](diffhunk://#diff-9a9d9da2fc02aebe484b6b984b510589bbf5015c2c0e89335aa07f06c958258fL244-R253)`, `[[3]](diffhunk://#diff-ae20cad6c5ce98ab82aba0c89f59cf19e47ec27d6fd3dbad19c909500e7d154dL301-R301)`, `[[4]](diffhunk://#diff-ae20cad6c5ce98ab82aba0c89f59cf19e47ec27d6fd3dbad19c909500e7d154dL334-R334)`, `[[5]](diffhunk://#diff-ae20cad6c5ce98ab82aba0c89f59cf19e47ec27d6fd3dbad19c909500e7d154dL349-R349)`, `[[6]](diffhunk://#diff-ae20cad6c5ce98ab82aba0c89f59cf19e47ec27d6fd3dbad19c909500e7d154dL362-R362)`)

### Miscellaneous:
* Changed button text from "Export Result" to "Download Result" for consistency across views. (`[[1]](diffhunk://#diff-9a9d9da2fc02aebe484b6b984b510589bbf5015c2c0e89335aa07f06c958258fL42-R42)`, `[[2]](diffhunk://#diff-ae20cad6c5ce98ab82aba0c89f59cf19e47ec27d6fd3dbad19c909500e7d154dL54-R54)`, `[[3]](diffhunk://#diff-4e1fcfd3d7d178d526d020d75047ede82435729b60e32c17c4d261b68b30814dL42-R42)`)