### PR TITLE
feat(Sidebar): Update sidebar links for Item Forecast Price and Item Price Adjustment

### DIFF
--- a/Futurist.Web/Views/Shared/_sidebar.cshtml
+++ b/Futurist.Web/Views/Shared/_sidebar.cshtml
@@ -74,21 +74,15 @@
                         </ul>
                     </div>
                 </li>
-                <li class="nav-item">
-                    <a href="#fgCostVersion" class="nav-link menu-link" data-bs-toggle="collapse" role="button"
-                       aria-expanded="false" aria-controls="sidebarProjects" data-key="t-projects">
-                        <i class="ri-calculator-line"></i> <span>FG Cost Version</span>
+                <li>
+                    <a class="nav-link menu-link" href="@Url.Action("Index", "ItemForecast")">
+                        <i class="ri-price-tag-2-fill"></i> <span>Item Forecast Price</span>
                     </a>
-                    <div class="collapse menu-dropdown" id="fgCostVersion">
-                        <ul class="nav nav-sm flex-column">
-                            <li class="nav-item">
-                                <a href="@Url.Action("Process", "FgCostVer")" class="nav-link" data-key="t-process"> Process </a>
-                            </li>
-                            <li class="nav-item">
-                                <a href="@Url.Action("Index", "FgCostVer")" class="nav-link" data-key="t-summary-by-item-id"> Summary </a>
-                            </li>
-                        </ul>
-                    </div>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link menu-link" href="@Url.Action("Index", "ItemAdjustment")">
+                        <i class="ri-price-tag-2-fill"></i> <span>Item Price Adjustment</span>
+                    </a>
                 </li>
                 <li class="nav-item">
                     <a href="#fgCalculation" class="nav-link menu-link" data-bs-toggle="collapse" role="button"
@@ -105,6 +99,22 @@
                             </li>
                             <li class="nav-item">
                                 <a href="@Url.Action("Details", "FgCost")" class="nav-link" data-key="t-details"> Details </a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+                <li class="nav-item">
+                    <a href="#fgCostVersion" class="nav-link menu-link" data-bs-toggle="collapse" role="button"
+                       aria-expanded="false" aria-controls="sidebarProjects" data-key="t-projects">
+                        <i class="ri-calculator-line"></i> <span>FG Cost Version</span>
+                    </a>
+                    <div class="collapse menu-dropdown" id="fgCostVersion">
+                        <ul class="nav nav-sm flex-column">
+                            <li class="nav-item">
+                                <a href="@Url.Action("Process", "FgCostVer")" class="nav-link" data-key="t-process"> Process </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="@Url.Action("Index", "FgCostVer")" class="nav-link" data-key="t-summary-by-item-id"> Summary </a>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
This pull request modifies the `_sidebar.cshtml` file to reorganize and adjust the navigation menu structure. The changes include rearranging menu items, updating links, and reintroducing a previously removed section for "FG Cost Version."

### Navigation menu updates:

* Replaced the "FG Cost Version" menu item with new links for "Item Forecast Price" and "Item Price Adjustment," each pointing to their respective controllers (`ItemForecast` and `ItemAdjustment`). This change simplifies the navigation structure by removing nested dropdowns.
* Reintroduced the "FG Cost Version" section as a collapsible menu with links for "Process" and "Summary," restoring the previously removed functionality.