### PR TITLE
feat: update authorization roles for JobMonitoringController and JobMonitoringApiController

### DIFF
--- a/Futurist.Web/Controllers/JobMonitoringController.cs
+++ b/Futurist.Web/Controllers/JobMonitoringController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Futurist.Web.Controllers;
 
-[Authorize(Roles = "admin")]
+[Authorize(Roles = "admin,costing")]
 public class JobMonitoringController : Controller
 {
     // GET
@@ -21,7 +21,7 @@ public class JobMonitoringController : Controller
 }
 
 [ApiController]
-[Authorize(Roles = "admin")]
+[Authorize(Roles = "admin,costing")]
 [Route("api/[controller]/[action]")]
 public class JobMonitoringApiController : ControllerBase
 {


### PR DESCRIPTION
This pull request updates role-based authorization in the `JobMonitoringController` and `JobMonitoringApiController` classes to include an additional role, "costing," alongside "admin."

Authorization updates:

* [`Futurist.Web/Controllers/JobMonitoringController.cs`](diffhunk://#diff-9fbd0fd8878332a2861d46cf94fce675aa1e2da38629ea3a5fa46653ca77aad1L8-R8): Updated the `[Authorize]` attribute to allow users with the "costing" role in addition to "admin" for the `JobMonitoringController` class.
* [`Futurist.Web/Controllers/JobMonitoringController.cs`](diffhunk://#diff-9fbd0fd8878332a2861d46cf94fce675aa1e2da38629ea3a5fa46653ca77aad1L24-R24): Updated the `[Authorize]` attribute for the `JobMonitoringApiController` class to include the "costing" role alongside "admin."