### PR TITLE
fix: update SQL query to reference correct database for invoice year selection

### DIFF
--- a/Futurist.Repository.SqlServer/ScmReportRepository.cs
+++ b/Futurist.Repository.SqlServer/ScmReportRepository.cs
@@ -94,7 +94,7 @@ public class ScmReportRepository : IScmReportRepository
                            SELECT DISTINCT YEAR(INVOICEDATE) AS Year
                            FROM [SCMBI].[dbo].[FactSalesInvoice]
                            ORDER BY Year DESC;
-                           SELECT DISTINCT YEAR(INVOICEDATE) AS Year FROM [AXDW].[dbo].[FactSalesInvoice] ORDER BY Year DESC;
+                           SELECT DISTINCT YEAR(INVOICEDATE) AS Year FROM [AXGMKDW].[dbo].[FactSalesInvoice] ORDER BY Year DESC;
                            """;
         
         return await _dbConnection.QueryAsync<int>(sql);


### PR DESCRIPTION
This pull request makes a small but important change to the database query in the `GetYearsAsync` method. The change updates the source database for fetching invoice years, ensuring data is retrieved from the correct location.

* Changed the SQL query in `ScmReportRepository.cs` to select distinct invoice years from the `[AXGMKDW].[dbo].[FactSalesInvoice]` table instead of `[AXDW].[dbo].[FactSalesInvoice]`.