### PR TITLE
feat(AnlRm): add MaterialPlan filter endpoints for VerIds, Years, and Months

### DIFF
--- a/Futurist.Repository.Command/AnlRmCommand/GetMaterialPlanMonthsCommand.cs
+++ b/Futurist.Repository.Command/AnlRmCommand/GetMaterialPlanMonthsCommand.cs
@@ -1,0 +1,8 @@
+namespace Futurist.Repository.Command.AnlRmCommand;
+
+public class GetMaterialPlanMonthsCommand : BaseCommand
+{
+    public int Room { get; set; }
+    public int VerId { get; set; }
+    public int Year { get; set; }
+}

--- a/Futurist.Repository.Command/AnlRmCommand/GetMaterialPlanVerIdsCommand.cs
+++ b/Futurist.Repository.Command/AnlRmCommand/GetMaterialPlanVerIdsCommand.cs
@@ -1,0 +1,6 @@
+namespace Futurist.Repository.Command.AnlRmCommand;
+
+public class GetMaterialPlanVerIdsCommand : BaseCommand
+{
+    public int Room { get; set; }
+}

--- a/Futurist.Repository.Command/AnlRmCommand/GetMaterialPlanYearsCommand.cs
+++ b/Futurist.Repository.Command/AnlRmCommand/GetMaterialPlanYearsCommand.cs
@@ -1,0 +1,7 @@
+namespace Futurist.Repository.Command.AnlRmCommand;
+
+public class GetMaterialPlanYearsCommand : BaseCommand
+{
+    public int Room { get; set; }
+    public int VerId { get; set; }
+}

--- a/Futurist.Repository.Interface/IAnlRmRepository.cs
+++ b/Futurist.Repository.Interface/IAnlRmRepository.cs
@@ -18,4 +18,7 @@ public interface IAnlRmRepository
     Task<IEnumerable<AnlCostPrice>> GetAnlCostPriceAsync(GetAnlCostPriceCommand command, CancellationToken cancellationToken);
     Task<IEnumerable<FgPlanCostPrice>> GetFgPlanCostPriceAsync(GetFgPlanCostPriceCommand command);
     Task<IEnumerable<BomStdVsActDet>> GetBomStdVsActDetAsync(GetBomStdVsActDetCommand command);
+    Task<IEnumerable<Versions>> GetMaterialPlanVerIdsAsync(GetMaterialPlanVerIdsCommand command, CancellationToken cancellationToken);
+    Task<IEnumerable<int>> GetMaterialPlanYearsAsync(GetMaterialPlanYearsCommand command, CancellationToken cancellationToken);
+    Task<IEnumerable<int>> GetMaterialPlanMonthsAsync(GetMaterialPlanMonthsCommand command, CancellationToken cancellationToken);
 }

--- a/Futurist.Repository.SqlServer/AnlRmRepository.cs
+++ b/Futurist.Repository.SqlServer/AnlRmRepository.cs
@@ -347,4 +347,56 @@ public class AnlRmRepository : IAnlRmRepository
             command.DbTransaction);
         return await _sqlConnection.QueryAsync<BomStdVsActDet>(sqlCommand);
     }
+
+    public async Task<IEnumerable<Versions>> GetMaterialPlanVerIdsAsync(GetMaterialPlanVerIdsCommand command, CancellationToken cancellationToken)
+    {
+        const string query = """
+                             SELECT DISTINCT v.VerId, v.VerDate, v.Room, v.Notes, v.Cancel
+                             FROM MaterialPlan mp
+                             JOIN [Version] v ON v.VerId = mp.VerId
+                             WHERE mp.Room = @Room
+                             ORDER BY v.VerId
+                             """;
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        var sqlCommand = new CommandDefinition(
+            query,
+            new { command.Room },
+            command.DbTransaction,
+            cancellationToken: cancellationToken);
+        return await _sqlConnection.QueryAsync<Versions>(sqlCommand);
+    }
+
+    public async Task<IEnumerable<int>> GetMaterialPlanYearsAsync(GetMaterialPlanYearsCommand command, CancellationToken cancellationToken)
+    {
+        const string query = """
+                             SELECT DISTINCT [Year]
+                             FROM MaterialPlan
+                             WHERE Room = @Room AND VerId = @VerId
+                             ORDER BY [Year]
+                             """;
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        var sqlCommand = new CommandDefinition(
+            query,
+            new { command.Room, command.VerId },
+            command.DbTransaction,
+            cancellationToken: cancellationToken);
+        return await _sqlConnection.QueryAsync<int>(sqlCommand);
+    }
+
+    public async Task<IEnumerable<int>> GetMaterialPlanMonthsAsync(GetMaterialPlanMonthsCommand command, CancellationToken cancellationToken)
+    {
+        const string query = """
+                             SELECT DISTINCT [Month]
+                             FROM MaterialPlan
+                             WHERE Room = @Room AND VerId = @VerId AND [Year] = @Year
+                             ORDER BY [Month]
+                             """;
+        await _sqlConnection.ExecuteAsync("SET ARITHABORT ON", transaction: command.DbTransaction);
+        var sqlCommand = new CommandDefinition(
+            query,
+            new { command.Room, command.VerId, command.Year },
+            command.DbTransaction,
+            cancellationToken: cancellationToken);
+        return await _sqlConnection.QueryAsync<int>(sqlCommand);
+    }
 }

--- a/Futurist.Service.Interface/IAnlRmService.cs
+++ b/Futurist.Service.Interface/IAnlRmService.cs
@@ -19,4 +19,7 @@ public interface IAnlRmService
         string itemId, CancellationToken cancellationToken);
     Task<ServiceResponse<IEnumerable<FgPlanCostPriceDto>>> GetFgPlanCostPriceAsync(int room, int verId, int year, int month);
     Task<ServiceResponse<IEnumerable<BomStdVsActDetDto>>> GetBomStdVsActDetAsync(int verId, int room, int tahun, int bulan, string productId);
+    Task<ServiceResponse<IEnumerable<VersionsDto>>> GetMaterialPlanVerIdsAsync(int room, CancellationToken cancellationToken);
+    Task<ServiceResponse<IEnumerable<int>>> GetMaterialPlanYearsAsync(int room, int verId, CancellationToken cancellationToken);
+    Task<ServiceResponse<IEnumerable<int>>> GetMaterialPlanMonthsAsync(int room, int verId, int year, CancellationToken cancellationToken);
 }

--- a/Futurist.Service/AnlRmService.cs
+++ b/Futurist.Service/AnlRmService.cs
@@ -403,4 +403,73 @@ public class AnlRmService : IAnlRmService
             };
         }
     }
+
+    public async Task<ServiceResponse<IEnumerable<VersionsDto>>> GetMaterialPlanVerIdsAsync(int room, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var command = new GetMaterialPlanVerIdsCommand { Room = room };
+            var result = await _unitOfWork.AnlRmRepository.GetMaterialPlanVerIdsAsync(command, cancellationToken);
+            return new ServiceResponse<IEnumerable<VersionsDto>>
+            {
+                Data = _mapper.MapToIEnumerableDto(result),
+                Message = ServiceMessageConstants.MaterialPlanVerIdsFound
+            };
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "GetMaterialPlanVerIds {@room}", room);
+            return new ServiceResponse<IEnumerable<VersionsDto>>
+            {
+                Errors = [e.Message],
+                Message = ServiceMessageConstants.MaterialPlanVerIdsNotFound
+            };
+        }
+    }
+
+    public async Task<ServiceResponse<IEnumerable<int>>> GetMaterialPlanYearsAsync(int room, int verId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var command = new GetMaterialPlanYearsCommand { Room = room, VerId = verId };
+            var result = await _unitOfWork.AnlRmRepository.GetMaterialPlanYearsAsync(command, cancellationToken);
+            return new ServiceResponse<IEnumerable<int>>
+            {
+                Data = result,
+                Message = ServiceMessageConstants.MaterialPlanYearsFound
+            };
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "GetMaterialPlanYears {@room} {@verId}", room, verId);
+            return new ServiceResponse<IEnumerable<int>>
+            {
+                Errors = [e.Message],
+                Message = ServiceMessageConstants.MaterialPlanYearsNotFound
+            };
+        }
+    }
+
+    public async Task<ServiceResponse<IEnumerable<int>>> GetMaterialPlanMonthsAsync(int room, int verId, int year, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var command = new GetMaterialPlanMonthsCommand { Room = room, VerId = verId, Year = year };
+            var result = await _unitOfWork.AnlRmRepository.GetMaterialPlanMonthsAsync(command, cancellationToken);
+            return new ServiceResponse<IEnumerable<int>>
+            {
+                Data = result,
+                Message = ServiceMessageConstants.MaterialPlanMonthsFound
+            };
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "GetMaterialPlanMonths {@room} {@verId} {@year}", room, verId, year);
+            return new ServiceResponse<IEnumerable<int>>
+            {
+                Errors = [e.Message],
+                Message = ServiceMessageConstants.MaterialPlanMonthsNotFound
+            };
+        }
+    }
 }

--- a/Futurist.Web/Controllers/AnlRmController.cs
+++ b/Futurist.Web/Controllers/AnlRmController.cs
@@ -190,4 +190,31 @@ public class AnlRmApiController : ControllerBase
             ? Ok(response)
             : BadRequest(response);
     }
+
+    [HttpGet]
+    public async Task<IActionResult> GetMaterialPlanVerIdsAsync([FromQuery] int room, CancellationToken cancellationToken)
+    {
+        var response = await _anlRmService.GetMaterialPlanVerIdsAsync(room, cancellationToken);
+        return response.IsSuccess
+            ? Ok(response)
+            : BadRequest(response);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetMaterialPlanYearsAsync([FromQuery] int room, [FromQuery] int verId, CancellationToken cancellationToken)
+    {
+        var response = await _anlRmService.GetMaterialPlanYearsAsync(room, verId, cancellationToken);
+        return response.IsSuccess
+            ? Ok(response)
+            : BadRequest(response);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetMaterialPlanMonthsAsync([FromQuery] int room, [FromQuery] int verId, [FromQuery] int year, CancellationToken cancellationToken)
+    {
+        var response = await _anlRmService.GetMaterialPlanMonthsAsync(room, verId, year, cancellationToken);
+        return response.IsSuccess
+            ? Ok(response)
+            : BadRequest(response);
+    }
 }

--- a/Futurist.Web/Views/AnlRm/FgPlanCostPrice.cshtml
+++ b/Futurist.Web/Views/AnlRm/FgPlanCostPrice.cshtml
@@ -110,7 +110,7 @@
             verIdSelect.select2({
                 placeholder: "Select Version",
                 ajax: {
-                    url: '/api/ReportVersionApi/GetVersions',
+                    url: '/api/AnlRmApi/GetMaterialPlanVerIds',
                     type: 'GET',
                     dataType: 'json',
                     delay: 500,
@@ -133,7 +133,7 @@
             yearSelect.select2({
                 placeholder: "Select Year",
                 ajax: {
-                    url: '/api/AnlRmApi/GetYears',
+                    url: '/api/AnlRmApi/GetMaterialPlanYears',
                     type: 'GET',
                     dataType: 'json',
                     delay: 500,
@@ -153,7 +153,7 @@
             monthSelect.select2({
                 placeholder: "Select Month",
                 ajax: {
-                    url: '/api/AnlRmApi/GetMonths',
+                    url: '/api/AnlRmApi/GetMaterialPlanMonths',
                     type: 'GET',
                     dataType: 'json',
                     delay: 500,


### PR DESCRIPTION
This pull request introduces new functionality for retrieving material plan versions, years, and months filtered by room, version, and year, and integrates these endpoints throughout the repository, service, controller, and frontend. The changes enable more granular selection of material plan data in the application.

**API and Backend Integration:**

* Added three new command classes (`GetMaterialPlanVerIdsCommand`, `GetMaterialPlanYearsCommand`, `GetMaterialPlanMonthsCommand`) to encapsulate parameters for material plan queries. [[1]](diffhunk://#diff-323386c5526e9698dab25b3055e3208f337f2d1b4e921a704a6f6ed878cae99eR1-R6) [[2]](diffhunk://#diff-555dcd9a6a83f09f1dc0c3b587e17223011dab92209989ea747601987cac5895R1-R7) [[3]](diffhunk://#diff-15152f6abc3255ac1f7e1ea9a2ba4a651fe33b7ef8b6fe9fa1ea2d01d420a245R1-R8)
* Implemented repository methods in `AnlRmRepository` for fetching distinct material plan versions, years, and months, with corresponding SQL queries.
* Updated `IAnlRmRepository` and `IAnlRmService` interfaces to include the new methods for material plan data retrieval. [[1]](diffhunk://#diff-1411132ef07a7006d495b979f14579f58d397ad15d48e95852f13755f193335fR21-R23) [[2]](diffhunk://#diff-bf4f2b8a132f68f52d19ce4237a28d5b3c5515156479f87df3b4057f080198f1R22-R24)
* Added service methods in `AnlRmService` to handle business logic and error handling for the new material plan queries.
* Introduced controller actions in `AnlRmController` to expose the new endpoints for material plan versions, years, and months via HTTP GET requests.

**Frontend Integration:**

* Updated AJAX calls in `FgPlanCostPrice.cshtml` to use the new endpoints for fetching selectable material plan versions, years, and months, replacing previous URLs. [[1]](diffhunk://#diff-8fd32f54a13c47bee40dbbaf988756eacc83029c774d07f82d1669005d6fc871L113-R113) [[2]](diffhunk://#diff-8fd32f54a13c47bee40dbbaf988756eacc83029c774d07f82d1669005d6fc871L136-R136) [[3]](diffhunk://#diff-8fd32f54a13c47bee40dbbaf988756eacc83029c774d07f82d1669005d6fc871L156-R156)